### PR TITLE
Fix off-by-one bug in feature collection

### DIFF
--- a/beancount_import/cli.py
+++ b/beancount_import/cli.py
@@ -178,8 +178,8 @@ class JournalState(object):
             w = w.strip('-.').lower()
             if len(w) > 0:
                 words.append(w)
-        for start_i in range(len(words)-1):
-            for end_i in range(start_i, len(words)):
+        for start_i in range(len(words)):
+            for end_i in range(start_i+1, len(words)+1):
                 features['phrase:%s' % ' '.join(words[start_i:end_i])] = True
         return features
 


### PR DESCRIPTION
I believe there is an off-by-one bug in the way phrases are put together - not all words are used, if my testing is correct.

Test code:

```
words = ['A', 'B', 'C']                                                                                                  
                                                                                                                         
# old code                                                                                                               
print '--- old ---'                                                                                                      
for start_i in range(len(words)-1):                                                                                      
    for end_i in range(start_i, len(words)):⋅                                                                            
        print ' '.join(words[start_i:end_i])                                                                             
                                                                                                                         
# new code                                                                                                               
print '--- new ---'                                                                                                      
for start_i in range(len(words)):                                                                                        
    for end_i in range(start_i+1, len(words)+1):⋅                                                                        
        print ' '.join(words[start_i:end_i]) 
```

Output:

```
--- old ---

A
A B

B
--- new ---
A
A B
A B C
B
B C
C
```

This pull request makes the necessary change, although I haven't actually tested it yet beyond the above reasoning. :-)

Thanks for beancount-import - great starting point to adapt for my own workflow! Cheers!