### PR TITLE
fix: Fix compatibility with Tornado 6.0

### DIFF
--- a/beancount_import/webserver.py
+++ b/beancount_import/webserver.py
@@ -264,7 +264,12 @@ class RetrainHandler(tornado.web.RequestHandler):
 class WebSocketHandler(tornado.websocket.WebSocketHandler):
     def open(self, *args):
         self.application.socket_clients.add(self)
-        self.set_nodelay(True)
+        try:
+            self.set_nodelay(True)
+        except:
+            # This results in an assertion error in Tornado 6.0.  Simply ignore
+            # it since the nodelay option isn't critical.
+            pass
         self.prev_state = dict()
         self.prev_state_generation = dict()
         self.watched_files = set()


### PR DESCRIPTION
When set_nodelay is called from the WebsocketHandler.open method in Tornado 6.0,
it results in an assertion failure.  This change introduces a workaround.