### PR TITLE
Fuzzy matching for posting weights.

### DIFF
--- a/beancount_import/reconcile.py
+++ b/beancount_import/reconcile.py
@@ -381,6 +381,7 @@ class LoadedReconciler(object):
 
         self.posting_db = matching.PostingDatabase(
             fuzzy_match_days=reconciler.options['fuzzy_match_days'],
+            fuzzy_match_amount=reconciler.options['fuzzy_match_amount'],
             is_cleared=self.is_posting_cleared,
             metadata_keys=frozenset([matching.CHECK_KEY]),
         )

--- a/beancount_import/reconcile_test.py
+++ b/beancount_import/reconcile_test.py
@@ -138,6 +138,7 @@ class ReconcileGoldenTester:
                 default_output=journal_path,
                 balance_account_output_map=[],
                 fuzzy_match_days=5,
+                fuzzy_match_amount=0,
                 account_pattern=None,
                 ignore_account_for_classification_pattern=training.
                 DEFAULT_IGNORE_ACCOUNT_FOR_CLASSIFICATION_PATTERN,

--- a/beancount_import/webserver.py
+++ b/beancount_import/webserver.py
@@ -23,7 +23,7 @@ import tornado.netutil
 import tornado.websocket
 
 from beancount.core.data import Transaction, Posting
-from beancount.core.number import MISSING, Decimal
+from beancount.core.number import MISSING, Decimal, D
 import beancount.parser.printer
 
 import watchdog.events
@@ -708,6 +708,13 @@ def parse_arguments(argv, **kwargs):
         default=5,
         help=
         'Maximum number of days by which the dates of two matching entries may differ.'
+    )
+    argparser.add_argument(
+        '--fuzzy_match_amount',
+        type=Decimal,
+        default=D('0.01'),
+        help=
+        'Maximum amount by which the weights of two matching entries may differ.'
     )
     argparser.add_argument(
         '--classifier_cache',


### PR DESCRIPTION
In some cases -- for example, matching a pay stub's deduction for a 401(k)
contribution to a mutual-fund purchase transaction from the retirement
account's statement -- it is desirable to match exact currency amounts with
the higher-precision computed weight of a posting at cost.

This change makes that possible by considering two postings to be a match if
their weight is in the same currency and within `fuzzy_match_amount` in value.
The amount defaults to 0.01.

One could imagine it desirable to specify different weights for different
currencies; that exercise is left for the future.