### PR TITLE
feature: support filtering by year for ultipro_google and stockplanconnect sources

### DIFF
--- a/beancount_import/source/ultipro_google.py
+++ b/beancount_import/source/ultipro_google.py
@@ -237,10 +237,11 @@ statement_filename_re = r'([0-9]{4}-[0-9]{2}-[0-9]{2}).statement-(.*)\.pdf'
 
 
 class UltiproSource(Config, Source):
-    def __init__(self, directory: str, rules, **kwargs) -> None:
+    def __init__(self, directory: str, rules, year: Optional[int] = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self.directory = directory
         self.rules = rules
+        self.year = year
         self.example_posting_key_extractors = {self.desc_key: None}
 
     def get_statement_path(self, pay_date: datetime.date, document: str) -> str:
@@ -253,7 +254,8 @@ class UltiproSource(Config, Source):
         if not isinstance(entry, Transaction): return None
         meta = entry.meta
         if (meta and self.pay_date_key in meta and self.document_key in meta):
-            return (meta[self.pay_date_key], meta[self.document_key])
+            if self.year is None or self.year == meta[self.pay_date_key].year:
+                return (meta[self.pay_date_key], meta[self.document_key])
         return None
 
     def _preprocess_entries(self, entries: Entries):


### PR DESCRIPTION
I organize most of my source documents by year, e.g. .../Pay
Statements/2018/2018-01-02.statement.pdf or .../Amazon
Invoices/2019/123-45678-9012.html.

For most sources, I can either use a recursive glob to pick up all the files
in the tree, or create one Source per year, and everything works fine. But for
stockplanconnect and ultipro_google, which expect to be able to translate from
a transaction in the journal to a source path based only on the document ID,
this doesn't work; if I use a recursive glob, every journal entry gets
declared invalid because the statements don't have the expected path, and if I
use one source per year-specific subdirectory, every entry ends up being
declared invalid by the sources that only expect to find documents from other
years.

This change allows the use of a separate source per year for
directory-per-year layouts, by adding a "year" parameter to these two sources,
and ignoring any journal entry from a date outside the configured year if
there is one.