### PR TITLE
feat(amazon): handle invoices with no per-shipment details

### DIFF
--- a/testdata/source/amazon/381-3642728-6932366.html
+++ b/testdata/source/amazon/381-3642728-6932366.html
@@ -1,0 +1,343 @@
+<html dir="ltr"><head>
+
+
+
+
+
+
+<title>Amazon.com - Order 381-3642728-6932366</title>
+
+</head>
+<body>
+
+<br/>
+<br clear='\"all\"'/>
+<center><b class="h1">
+            Final Details for Order #381-3642728-6932366
+  </b><br/>
+<a onclick="javascript:window.print();">Print this page for your records.</a>
+</center><br/>
+<table align="center" bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="0" width="90%">
+<tbody><tr>
+<td>
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr><td align="left" valign="top">
+<b>
+                Order Placed:
+          </b>
+          September 12, 2019
+        </td></tr>
+<tr><td align="left" valign="top">
+<b>Amazon.com order number:</b>
+          381-3642728-6932366
+        </td></tr>
+<tr><td align="left" valign="top">
+<b>Order Total:
+          $63.32</b>
+</td></tr>
+</tbody></table>
+<br/>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#000000">
+<td>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="3" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td colspan="2" valign="top">
+<table border="0" cellpadding="5" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td>
+<b class="sans"></b><center>
+                  Shipped on September 13, 2019
+
+
+                  </center>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr valign="top">
+<td width="100%">
+<table align="right" border="0" cellpadding="2" cellspacing="0">
+<tbody><tr valign="top">
+<td align="right">
+                         
+                      </td>
+</tr>
+</tbody></table>
+<table border="0" cellpadding="0" cellspacing="2" width="100%">
+<tbody><tr valign="top">
+<td valign="top">
+<b>Items Ordered</b>
+</td>
+<td align="right" valign="top">
+<b>Price</b>
+</td>
+</tr>
+<tr>
+
+<td colspan="1" valign="top">
+    
+    1
+
+    of:
+
+    <i>Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A</i><br/>
+<span class="tiny">
+      Sold by: Princeton Watches (<a>seller profile</a>)
+  
+  
+  
+  
+    
+    
+    
+    
+    
+    
+    
+    
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br/>
+<br/>
+
+      Condition: New<br/>
+</span>
+</td>
+<td align="right" colspan="2" valign="top">
+    
+    $91.25<br/>
+</td></tr>
+</tbody></table>
+<br/>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr>
+<td>
+<b>
+
+</b>
+<br/>
+
+
+
+
+
+
+</ul>
+</div>
+<br/><b>
+Shipping Speed:
+</b>
+<br/>
+Two-Day Shipping
+<br/>
+</td>
+<td align="right">
+<table border="0" cellpadding="0" cellspacing="1">
+</table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<br/>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#000000">
+<td>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="3" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td colspan="2" valign="top">
+<table border="0" cellpadding="5" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td>
+<b class="sans"></b><center>Payment information</center>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr valign="top">
+<td width="100%">
+<table align="right" border="0" cellpadding="2" cellspacing="0">
+<tbody><tr valign="top">
+<td align="right">
+<table border="0" cellpadding="0" cellspacing="1">
+<tbody><tr valign="top">
+<td align="right" nowrap="nowrap">Item(s) Subtotal: </td>
+<td align="right" nowrap="nowrap">$91.25</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Shipping &amp; Handling:</td>
+<td align="right" nowrap="nowrap">$0.00</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap"> </td>
+<td align="right" nowrap="nowrap">-----</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Total before tax:</td>
+<td align="right" nowrap="nowrap">$91.25</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Estimated tax to be collected:</td>
+<td align="right" nowrap="nowrap">$8.44</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Gift Card Amount:</td>
+<td align="right" nowrap="nowrap">-$36.37</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap"> </td>
+<td align="right" nowrap="nowrap">-----</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap"><b>Grand Total:</b></td>
+<td align="right" nowrap="nowrap"><b>$63.32</b></td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<b>Payment Method: </b>
+<br/>
+
+
+    Amazon.com Visa Signature
+    <nobr> | Last digits:  1234</nobr>
+<br/> 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      Gift Card<br/>
+<br/>
+
+
+
+
+
+
+
+</ul>
+</div>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr>
+<td valign="top">
+<div style="text-align:left;"><b>Credit Card transactions </b></div>
+</td>
+<td align="right">
+<table border="0" cellpadding="0" cellspacing="1">
+<tbody><tr valign="top">
+<td align="right" nowrap="nowrap">
+      Visa ending in 1234: September 13, 2019:
+    </td>
+<td align="right" colspan="2" nowrap="nowrap">
+      $63.32
+    </td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<center>
+<p>To view the status of your order, return to <a>Order Summary</a>.</p>
+</center>
+
+<br/>
+<center class="tiny">
+<a rel="nofollow">Conditions of Use</a>
+|
+<a rel="nofollow">Privacy Notice</a>
+© 9054-3260, Amazon.com, Inc. or its affiliates
+</center>
+
+
+
+
+<div id="be" style="display:none;visibility:hidden;"><form name="ue_backdetect"></form>
+<a>v</a>
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</body></html>

--- a/testdata/source/amazon/511-1525861-4349605.html
+++ b/testdata/source/amazon/511-1525861-4349605.html
@@ -1,0 +1,490 @@
+<html dir="ltr"><head>
+
+
+
+
+
+
+<title>Amazon.com - Order 511-1525861-4349605</title>
+
+</head>
+<body>
+
+<br/>
+<br clear='\"all\"'/>
+<center><b class="h1">
+            Final Details for Order #511-1525861-4349605
+  </b><br/>
+<a onclick="javascript:window.print();">Print this page for your records.</a>
+</center><br/>
+<table align="center" bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="0" width="90%">
+<tbody><tr>
+<td>
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr><td align="left" valign="top">
+<b>
+                Order Placed:
+          </b>
+          September 18, 2019
+        </td></tr>
+<tr><td align="left" valign="top">
+<b>Amazon.com order number:</b>
+          511-1525861-4349605
+        </td></tr>
+<tr><td align="left" valign="top">
+<b>Order Total:
+          $0.00</b>
+</td></tr>
+</tbody></table>
+<br/>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#000000">
+<td>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="3" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td colspan="2" valign="top">
+<table border="0" cellpadding="5" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td>
+<b class="sans"></b><center>
+                  Shipped on September 18, 2019
+
+
+                  </center>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr valign="top">
+<td width="100%">
+<table align="right" border="0" cellpadding="2" cellspacing="0">
+<tbody><tr valign="top">
+<td align="right">
+                         
+                      </td>
+</tr>
+</tbody></table>
+<table border="0" cellpadding="0" cellspacing="2" width="100%">
+<tbody><tr valign="top">
+<td valign="top">
+<b>Items Ordered</b>
+</td>
+<td align="right" valign="top">
+<b>Price</b>
+</td>
+</tr>
+<tr>
+
+<td colspan="1" valign="top">
+    
+    1
+
+    of:
+
+    <i>DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes</i><br/>
+<span class="tiny">
+      Sold by: Bo Bao (<a>seller profile</a>)
+  
+  
+  
+  
+    
+    
+    
+    
+    
+    
+    
+    
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br/>
+<br/>
+
+      Condition: New<br/>
+</span>
+</td>
+<td align="right" colspan="2" valign="top">
+    
+    $26.99<br/>
+</td></tr>
+</tbody></table>
+<br/>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr>
+<td>
+<b>
+
+</b>
+<br/>
+
+
+
+
+
+
+</ul>
+</div>
+<br/><b>
+Shipping Speed:
+</b>
+<br/>
+One-Day Shipping
+<br/>
+</td>
+<td align="right">
+<table border="0" cellpadding="0" cellspacing="1">
+</table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<br/>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#000000">
+<td>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="3" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td colspan="2" valign="top">
+<table border="0" cellpadding="5" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td>
+<b class="sans"></b><center>
+                  Shipped on September 19, 2019
+
+
+                  </center>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr valign="top">
+<td width="100%">
+<table align="right" border="0" cellpadding="2" cellspacing="0">
+<tbody><tr valign="top">
+<td align="right">
+                         
+                      </td>
+</tr>
+</tbody></table>
+<table border="0" cellpadding="0" cellspacing="2" width="100%">
+<tbody><tr valign="top">
+<td valign="top">
+<b>Items Ordered</b>
+</td>
+<td align="right" valign="top">
+<b>Price</b>
+</td>
+</tr>
+<tr>
+
+<td colspan="1" valign="top">
+    
+    1
+
+    of:
+
+    <i>Aeromax Jr. Astronaut Backpack, White, with NASA patches</i><br/>
+<span class="tiny">
+      Sold by: Amazon.com Services, Inc
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+  
+  
+    
+    
+    
+    
+    
+    
+<br/>
+<br/>
+
+      Condition: New<br/>
+</span>
+</td>
+<td align="right" colspan="2" valign="top">
+    
+    $26.85<br/>
+</td></tr>
+<tr>
+
+<td colspan="1" valign="top">
+    
+    1
+
+    of:
+
+    <i>2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors</i><br/>
+<span class="tiny">
+      Sold by: Wrestler  Case (<a>seller profile</a>)
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+  
+  
+    
+    
+    
+    
+    
+     <span style="color: #000">|</span> Product question? <a>Ask Seller</a>
+<br/>
+<br/>
+
+      Condition: New<br/>
+</span>
+</td>
+<td align="right" colspan="2" valign="top">
+    
+    $12.89<br/>
+</td></tr>
+</tbody></table>
+<br/>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr>
+<td>
+<b>
+
+</b>
+<br/>
+
+
+
+
+
+
+</ul>
+</div>
+<br/><b>
+Shipping Speed:
+</b>
+<br/>
+One-Day Shipping
+<br/>
+</td>
+<td align="right">
+<table border="0" cellpadding="0" cellspacing="1">
+</table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<br/>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#000000">
+<td>
+<table align="center" bgcolor="#000000" border="0" cellpadding="0" cellspacing="3" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td colspan="2" valign="top">
+<table border="0" cellpadding="5" cellspacing="0" width="100%">
+<tbody><tr bgcolor="#ffffff">
+<td>
+<b class="sans"></b><center>Payment information</center>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+<tr>
+<td bgcolor="#ffffff" colspan="2" valign="top">
+<table border="0" cellpadding="2" cellspacing="0" width="100%">
+<tbody><tr valign="top">
+<td width="100%">
+<table align="right" border="0" cellpadding="2" cellspacing="0">
+<tbody><tr valign="top">
+<td align="right">
+<table border="0" cellpadding="0" cellspacing="1">
+<tbody><tr valign="top">
+<td align="right" nowrap="nowrap">Item(s) Subtotal: </td>
+<td align="right" nowrap="nowrap">$66.73</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Shipping &amp; Handling:</td>
+<td align="right" nowrap="nowrap">$0.00</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap"> </td>
+<td align="right" nowrap="nowrap">-----</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Total before tax:</td>
+<td align="right" nowrap="nowrap">$66.73</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Estimated tax to be collected:</td>
+<td align="right" nowrap="nowrap">$2.48</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap">Gift Card Amount:</td>
+<td align="right" nowrap="nowrap">-$69.21</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap"> </td>
+<td align="right" nowrap="nowrap">-----</td>
+</tr>
+<tr valign="top">
+<td align="right" nowrap="nowrap"><b>Grand Total:</b></td>
+<td align="right" nowrap="nowrap"><b>$0.00</b></td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<b>Payment Method: </b>
+<br/>
+
+
+    Amazon.com Visa Signature
+    <nobr> | Last digits:  1234</nobr>
+<br/> 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      Gift Card<br/>
+<br/>
+
+
+
+
+
+
+
+</ul>
+</div>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+</td>
+</tr>
+</tbody></table>
+<center>
+<p>To view the status of your order, return to <a>Order Summary</a>.</p>
+</center>
+
+<br/>
+<center class="tiny">
+<a rel="nofollow">Conditions of Use</a>
+|
+<a rel="nofollow">Privacy Notice</a>
+© 5976-1763, Amazon.com, Inc. or its affiliates
+</center>
+
+
+
+
+
+<div id="be" style="display:none;visibility:hidden;"><form name="ue_backdetect"></form>
+<a>v</a>
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</body></html>

--- a/testdata/source/amazon/test_basic/import_results.beancount
+++ b/testdata/source/amazon/test_basic/import_results.beancount
@@ -337,3 +337,113 @@
   Expenses:FIXME     -7.99 USD
     amazon_credit_card_description: "Amazon.com Store Card ending in 1234"
     transaction_date: 2017-03-28
+
+;; date: 2019-09-12
+;; info: {"filename": "<testdata>/381-3642728-6932366.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "8.44 USD",
+;               "date": "2019-09-12",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "-63.32 USD",
+;               "date": "2019-09-12",
+;               "key_value_pairs": {
+;                 "amazon_credit_card_description": [
+;                   "Visa ending in 1234"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-09-12 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "381-3642728-6932366"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"381-3642728-6932366\"], \"path\": \"<testdata>/381-3642728-6932366.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           91.25 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+    amazon_item_quantity: 1
+    amazon_seller: "Princeton Watches"
+    shipped_date: 2019-09-13
+  Expenses:FIXME:A            8.44 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -36.37 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Expenses:FIXME            -63.32 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2019-09-13
+
+;; date: 2019-09-18
+;; info: {"filename": "<testdata>/511-1525861-4349605.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "26.99 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "12.89 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Aeromax Jr. Astronaut Backpack, White, with NASA patches",
+;                   "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             null,
+;             {
+;               "amount": "0.00 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_credit_card_description": [
+;                   "Amazon.com Visa Signature ending in 1234"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-09-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "511-1525861-4349605"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"511-1525861-4349605\"], \"path\": \"<testdata>/511-1525861-4349605.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           26.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+    amazon_item_quantity: 1
+    amazon_seller: "Bo Bao"
+    shipped_date: 2019-09-18
+  Expenses:FIXME:B           26.85 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Aeromax Jr. Astronaut Backpack, White, with NASA patches"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services, Inc"
+    shipped_date: 2019-09-19
+  Expenses:FIXME:B           12.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+    amazon_item_quantity: 1
+    amazon_seller: "Wrestler Case"
+    shipped_date: 2019-09-19
+  Expenses:FIXME              2.48 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -69.21 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Expenses:FIXME              0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2019-09-18

--- a/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
+++ b/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
@@ -58,3 +58,93 @@
   Liabilities:Credit-Card  -14.99 USD
     amazon_credit_card_description: "VISA ending in 1234"
     transaction_date: 2016-06-30
+
+;; date: 2019-09-12
+;; info: {"filename": "<testdata>/381-3642728-6932366.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "8.44 USD",
+;               "date": "2019-09-12",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-09-12 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "381-3642728-6932366"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"381-3642728-6932366\"], \"path\": \"<testdata>/381-3642728-6932366.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           91.25 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+    amazon_item_quantity: 1
+    amazon_seller: "Princeton Watches"
+    shipped_date: 2019-09-13
+  Expenses:FIXME:A            8.44 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -36.37 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card   -63.32 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2019-09-13
+
+;; date: 2019-09-18
+;; info: {"filename": "<testdata>/511-1525861-4349605.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "26.99 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "12.89 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Aeromax Jr. Astronaut Backpack, White, with NASA patches",
+;                   "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             null
+;           ]
+2019-09-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "511-1525861-4349605"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"511-1525861-4349605\"], \"path\": \"<testdata>/511-1525861-4349605.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           26.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+    amazon_item_quantity: 1
+    amazon_seller: "Bo Bao"
+    shipped_date: 2019-09-18
+  Expenses:FIXME:B           26.85 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Aeromax Jr. Astronaut Backpack, White, with NASA patches"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services, Inc"
+    shipped_date: 2019-09-19
+  Expenses:FIXME:B           12.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+    amazon_item_quantity: 1
+    amazon_seller: "Wrestler Case"
+    shipped_date: 2019-09-19
+  Expenses:FIXME              2.48 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -69.21 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card     0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2019-09-18

--- a/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
+++ b/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
@@ -247,3 +247,93 @@
   Liabilities:Credit-Card   -7.99 USD
     amazon_credit_card_description: "Amazon.com Store Card ending in 1234"
     transaction_date: 2017-03-28
+
+;; date: 2019-09-12
+;; info: {"filename": "<testdata>/381-3642728-6932366.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "8.44 USD",
+;               "date": "2019-09-12",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-09-12 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "381-3642728-6932366"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"381-3642728-6932366\"], \"path\": \"<testdata>/381-3642728-6932366.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           91.25 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+    amazon_item_quantity: 1
+    amazon_seller: "Princeton Watches"
+    shipped_date: 2019-09-13
+  Expenses:FIXME:A            8.44 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -36.37 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card   -63.32 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2019-09-13
+
+;; date: 2019-09-18
+;; info: {"filename": "<testdata>/511-1525861-4349605.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "26.99 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "12.89 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Aeromax Jr. Astronaut Backpack, White, with NASA patches",
+;                   "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             null
+;           ]
+2019-09-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "511-1525861-4349605"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"511-1525861-4349605\"], \"path\": \"<testdata>/511-1525861-4349605.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           26.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+    amazon_item_quantity: 1
+    amazon_seller: "Bo Bao"
+    shipped_date: 2019-09-18
+  Expenses:FIXME:B           26.85 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Aeromax Jr. Astronaut Backpack, White, with NASA patches"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services, Inc"
+    shipped_date: 2019-09-19
+  Expenses:FIXME:B           12.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+    amazon_item_quantity: 1
+    amazon_seller: "Wrestler Case"
+    shipped_date: 2019-09-19
+  Expenses:FIXME              2.48 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -69.21 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card     0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2019-09-18

--- a/testdata/source/amazon/test_prediction/import_results.beancount
+++ b/testdata/source/amazon/test_prediction/import_results.beancount
@@ -68,3 +68,113 @@
   Liabilities:Credit-Card  -14.99 USD
     amazon_credit_card_description: "VISA ending in 1234"
     transaction_date: 2016-06-30
+
+;; date: 2019-09-12
+;; info: {"filename": "<testdata>/381-3642728-6932366.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "8.44 USD",
+;               "date": "2019-09-12",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "-36.37 USD",
+;               "date": "2019-09-12",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Gift Card Amount"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-09-12 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "381-3642728-6932366"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"381-3642728-6932366\"], \"path\": \"<testdata>/381-3642728-6932366.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A          91.25 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Citizen CTO Silver Dial Leather Strap Men's Watch BM2873-93A"
+    amazon_item_quantity: 1
+    amazon_seller: "Princeton Watches"
+    shipped_date: 2019-09-13
+  Expenses:FIXME:A           8.44 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME           -36.37 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card  -63.32 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2019-09-13
+
+;; date: 2019-09-18
+;; info: {"filename": "<testdata>/511-1525861-4349605.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "26.99 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "12.89 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Aeromax Jr. Astronaut Backpack, White, with NASA patches",
+;                   "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             null,
+;             {
+;               "amount": "-69.21 USD",
+;               "date": "2019-09-18",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Gift Card Amount"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-09-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "511-1525861-4349605"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"511-1525861-4349605\"], \"path\": \"<testdata>/511-1525861-4349605.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A          26.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "DLGJPA Men's Quick Drying Water Shoes for Beach or Water Sports Lightweight Slip On Walking Shoes"
+    amazon_item_quantity: 1
+    amazon_seller: "Bo Bao"
+    shipped_date: 2019-09-18
+  Expenses:FIXME:B          26.85 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Aeromax Jr. Astronaut Backpack, White, with NASA patches"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services, Inc"
+    shipped_date: 2019-09-19
+  Expenses:FIXME:B          12.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "2 Pairs Alien Glasses Silver Glasses with Rainbow Color Lens and 2 Pieces Martian Antenna Headband Boppers for Halloween Adults and Kids Party Favors"
+    amazon_item_quantity: 1
+    amazon_seller: "Wrestler Case"
+    shipped_date: 2019-09-19
+  Expenses:FIXME             2.48 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME           -69.21 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card    0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2019-09-18


### PR DESCRIPTION
Amazon has recently changed their invoice format to remove the per-shipment
totals tables (see issue #26 ). This change loosens parsing to handle such
invoices, without breaking parsing of older invoices.

Pre-tax adjustments and sales tax, if not present in the shipment tables, are
added at the per-invoice level instead. If there is only one shipment in the
transaction, they continue to be grouped with the lone shipment; otherwise,
like unrecognized post-tax adjustments, each is ungrouped.