### PR TITLE
fix(amount_parsing): Several parser improvements.

### DIFF
--- a/beancount_import/amount_parsing.py
+++ b/beancount_import/amount_parsing.py
@@ -30,12 +30,14 @@ def parse_amount(x):
     if not x:
         return None
     sign, amount_str = parse_possible_negative(x)
-    m = re.fullmatch(r'([\$€£])?([0-9]+(?:,[0-9]+)*(?:\.[0-9]*)?)(?:\s+([A-Z]{3}))?', amount_str)
+    m = re.fullmatch(r'([\$€£])?((?:[0-9](?:,?[0-9])*|(?=\.))(?:\.[0-9]+)?)(?:\s+([A-Z]{3}))?', amount_str)
     if m is None:
         raise ValueError('Failed to parse amount from %r' % amount_str)
     if m.group(1):
         currency = {'$': 'USD', '€': 'EUR', '£': 'GBP'}[m.group(1)]
-    number = D(m.group(2))
-    if m.group(3):
+    elif m.group(3):
         currency = m.group(3)
+    else:
+        raise ValueError('Failed to determine currency from %r' % amount_str)
+    number = D(m.group(2))
     return Amount(number * sign, currency)

--- a/beancount_import/amount_parsing_test.py
+++ b/beancount_import/amount_parsing_test.py
@@ -1,0 +1,71 @@
+from beancount.core.number import D
+from beancount.core.amount import Amount
+from .amount_parsing import parse_amount
+
+def test_parsing():
+    cases = {
+        '$12345.67': Amount(D('12345.67'), 'USD'),
+        '$12,345.67': Amount(D('12345.67'), 'USD'),
+        '$12.34': Amount(D('12.34'), 'USD'),
+        '+$123': Amount(D('123'), 'USD'),
+        '$1.23': Amount(D('1.23'), 'USD'),
+        '$0.12': Amount(D('0.12'), 'USD'),
+        '$0': Amount(D('0'), 'USD'),
+        '$0.00': Amount(D('0.00'), 'USD'),
+        '$.12': Amount(D('0.12'), 'USD'),
+        '-$.12': Amount(D('-0.12'), 'USD'),
+        '-$123.45': Amount(D('-123.45'), 'USD'),
+
+        '12345.67 CAD': Amount(D('12345.67'), 'CAD'),
+        '12,345.67 CAD': Amount(D('12345.67'), 'CAD'),
+        '12.34 CAD': Amount(D('12.34'), 'CAD'),
+        '+123 CAD': Amount(D('123'), 'CAD'),
+        '1.23 CAD': Amount(D('1.23'), 'CAD'),
+        '0.12 CAD': Amount(D('0.12'), 'CAD'),
+        '0 CAD': Amount(D('0'), 'CAD'),
+        '0.00 CAD': Amount(D('0.00'), 'CAD'),
+        '.12 CAD': Amount(D('0.12'), 'CAD'),
+        '-.12 CAD': Amount(D('-0.12'), 'CAD'),
+        '-123.45 CAD': Amount(D('-123.45'), 'CAD'),
+
+        '€12345.67': Amount(D('12345.67'), 'EUR'),
+        '€12,345.67': Amount(D('12345.67'), 'EUR'),
+        '+€123': Amount(D('123'), 'EUR'),
+        '€12.34': Amount(D('12.34'), 'EUR'),
+        '€1.23': Amount(D('1.23'), 'EUR'),
+        '€0.12': Amount(D('0.12'), 'EUR'),
+        '€.12': Amount(D('0.12'), 'EUR'),
+        '€0': Amount(D('0'), 'EUR'),
+        '€0.00': Amount(D('0.00'), 'EUR'),
+        '-€.12': Amount(D('-0.12'), 'EUR'),
+        '-€123.45': Amount(D('-123.45'), 'EUR'),
+        '£12345.67': Amount(D('12345.67'), 'GBP'),
+        '£12,345.67': Amount(D('12345.67'), 'GBP'),
+        '+£123': Amount(D('123'), 'GBP'),
+        '£12.34': Amount(D('12.34'), 'GBP'),
+        '£1.23': Amount(D('1.23'), 'GBP'),
+        '£0.12': Amount(D('0.12'), 'GBP'),
+        '£0': Amount(D('0'), 'GBP'),
+        '£0.00': Amount(D('0.00'), 'GBP'),
+        '£.12': Amount(D('0.12'), 'GBP'),
+        '-£.12': Amount(D('-0.12'), 'GBP'),
+        '-£123.45': Amount(D('-123.45'), 'GBP'),
+
+        '$': None,
+        '$.': None,
+        '€0.': None,
+        '£,': None,
+        '$123,.00': None,
+        '€,123.00': None,
+        '£,47.1': None,
+        '$€!@#$': None,
+        ' INS': None,
+        "I'm a parrot, cluck cluck": None,
+        '1,234,567.89': None,
+    }
+    for input, expected in cases.items():
+        try:
+            actual = parse_amount(input)
+        except ValueError:
+            actual = None
+        assert expected == actual, input


### PR DESCRIPTION
* Accept fractional amounts with no leading zero, e.g. $.10
* Reject amounts that end with a dot with no fraction, e.g. $123.
* Raise a proper error when currency is missing, instead of UnboundLocalError.
* Add comprehensive tests.