### PR TITLE
Add Missing Cash Balance Entries for Investments

### DIFF
--- a/beancount_import/source/ofx.py
+++ b/beancount_import/source/ofx.py
@@ -672,6 +672,16 @@ class ParsedOfxStatement(object):
             availcash = find_child(inv_bal, 'availcash', D)
             self.availcash = availcash
 
+            for bal in inv_bal.find_all('bal'):
+                if find_child(bal, 'value', D) == availcash:
+                    date = find_child(bal, 'dtasof', parse_ofx_time)
+                    if date is not None:
+                        date = date.date()
+                        raw_cash_balance_entries.append(
+                            RawCashBalanceEntry(
+                                date=date, number=availcash, filename=filename))
+                        break
+
         for bal in stmtrs.find_all('ledgerbal'):
             bal_amount_str = find_child(bal, 'balamt')
             if not bal_amount_str.strip(): continue

--- a/beancount_import/source/ofx_test.py
+++ b/beancount_import/source/ofx_test.py
@@ -33,6 +33,7 @@ examples = [
     ('test_checking2', 'checking2.ofx'),
     ('test_checking2_matching', 'checking2.ofx'),
     ('test_amex', 'amex.ofx'),
+    ('test_fidelity', 'fidelity.ofx'),
 ]
 
 

--- a/testdata/source/ofx/test_fidelity/accounts.txt
+++ b/testdata/source/ofx/test_fidelity/accounts.txt
@@ -1,0 +1,9 @@
+Assets:Investment:Fidelity
+Assets:Investment:Fidelity:CLCT
+Assets:Investment:Fidelity:Cash
+Assets:Investment:Fidelity:HI
+Assets:Investment:Fidelity:INTC
+Assets:Investment:Fidelity:RHT
+Assets:Investment:Fidelity:SDRL
+Assets:Investment:Fidelity:SPY
+Assets:Investment:Fidelity:XIN

--- a/testdata/source/ofx/test_fidelity/import_results.beancount
+++ b/testdata/source/ofx/test_fidelity/import_results.beancount
@@ -1,0 +1,277 @@
+;; date: 2012-07-20
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-07-20 * "BUYSTOCK - YOU BOUGHT"
+  Assets:Investment:Fidelity:INTC                100 INTC {25.635 USD}
+    date: 2012-07-20
+    ofx_fitid: "0123456789020201120120720"
+    ofx_memo: "YOU BOUGHT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash           -2571.45 USD
+    ofx_fitid: "0123456789020201120120720"
+  Expenses:Investment:Fidelity:Commissions    7.9500 USD
+
+;; date: 2012-07-27
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-07-27 * "BUYSTOCK - YOU BOUGHT"
+  Assets:Investment:Fidelity:SDRL                128 SDRL {39.3909 USD}
+    date: 2012-07-27
+    ofx_fitid: "0123456789020901120120727"
+    ofx_memo: "YOU BOUGHT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash           -5049.99 USD
+    ofx_fitid: "0123456789020901120120727"
+  Expenses:Investment:Fidelity:Commissions    7.9500 USD
+
+;; date: 2012-07-27
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-07-27 * "BUYSTOCK - YOU BOUGHT"
+  Assets:Investment:Fidelity:HI                  115 HI {17.25 USD}
+    date: 2012-07-27
+    ofx_fitid: "0123456789020901220120727"
+    ofx_memo: "YOU BOUGHT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash           -1991.70 USD
+    ofx_fitid: "0123456789020901220120727"
+  Expenses:Investment:Fidelity:Commissions    7.9500 USD
+
+;; date: 2012-07-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-07-31 * "BUYSTOCK - YOU BOUGHT"
+  Assets:Investment:Fidelity:CLCT                 69 CLCT {14.4699 USD}
+    date: 2012-07-31
+    ofx_fitid: "0123456789021301120120731"
+    ofx_memo: "YOU BOUGHT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash           -1006.37 USD
+    ofx_fitid: "0123456789021301120120731"
+  Expenses:Investment:Fidelity:Commissions    7.9500 USD
+
+;; date: 2012-07-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-07-31 * "BUYSTOCK - YOU BOUGHT"
+  Assets:Investment:Fidelity:XIN                 386 XIN {2.5887 USD}
+    date: 2012-07-31
+    ofx_fitid: "0123456789021301620120731"
+    ofx_memo: "YOU BOUGHT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash           -1007.19 USD
+    ofx_fitid: "0123456789021301620120731"
+  Expenses:Investment:Fidelity:Commissions    7.9500 USD
+
+;; date: 2012-07-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-07-31 * "INCOME - DIV - DIVIDEND RECEIVED"
+  Assets:Investment:Fidelity:Cash   5.53 USD
+    date: 2012-07-31
+    ofx_fitid: "0123456789021301520120731"
+    ofx_memo: "DIVIDEND RECEIVED"
+    ofx_type: "INCOME"
+  Income:Fidelity:Dividends:SPY    -5.53 USD
+
+;; date: 2012-07-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: [
+;             {
+;               "amount": "0.24 USD",
+;               "date": "2012-07-31",
+;               "key_value_pairs": {
+;                 "desc": "INTEREST EARNED",
+;                 "ofx_memo": "INTEREST EARNED",
+;                 "ofx_type": "INVBANKTRAN"
+;               },
+;               "source_account": "Assets:Investment:Fidelity:Cash"
+;             }
+;           ]
+2012-07-31 * "INVBANKTRAN - INTEREST EARNED"
+  Assets:Investment:Fidelity:Cash   0.24 USD
+    date: 2012-07-31
+    ofx_fitid: "0123456789021301320120731"
+    ofx_memo: "INTEREST EARNED"
+    ofx_type: "INVBANKTRAN"
+  Expenses:FIXME                   -0.24 USD
+
+;; date: 2012-08-20
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-08-20 * "BUYSTOCK - REINVESTMENT"
+  Assets:Investment:Fidelity:XIN    4.909 XIN {2.9474 USD}
+    date: 2012-08-20
+    ofx_fitid: "0123456789023501220120820"
+    ofx_memo: "REINVESTMENT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash  -14.47 USD
+    ofx_fitid: "0123456789023501220120820"
+
+;; date: 2012-08-20
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-08-20 * "INCOME - DIV - DIVIDEND RECEIVED"
+  Assets:Investment:Fidelity:Cash   15.44 USD
+    date: 2012-08-20
+    ofx_fitid: "0123456789023501320120820"
+    ofx_memo: "DIVIDEND RECEIVED"
+    ofx_type: "INCOME"
+  Income:Fidelity:Dividends:XIN    -15.44 USD
+
+;; date: 2012-08-20
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: [
+;             {
+;               "amount": "-0.97 USD",
+;               "date": "2012-08-20",
+;               "key_value_pairs": {
+;                 "desc": "LATE SETTLEMENT FEE",
+;                 "ofx_memo": "LATE SETTLEMENT FEE",
+;                 "ofx_type": "INVBANKTRAN"
+;               },
+;               "source_account": "Assets:Investment:Fidelity:Cash"
+;             }
+;           ]
+2012-08-20 * "INVBANKTRAN - LATE SETTLEMENT FEE"
+  Assets:Investment:Fidelity:Cash  -0.97 USD
+    date: 2012-08-20
+    ofx_fitid: "0123456789023501120120820"
+    ofx_memo: "LATE SETTLEMENT FEE"
+    ofx_type: "INVBANKTRAN"
+  Expenses:FIXME                    0.97 USD
+
+;; date: 2012-08-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-08-31 * "BUYSTOCK - REINVESTMENT"
+  Assets:Investment:Fidelity:CLCT   1.573 CLCT {14.257 USD}
+    date: 2012-08-31
+    ofx_fitid: "0123456789024401120120831"
+    ofx_memo: "REINVESTMENT"
+    ofx_type: "BUYSTOCK"
+  Assets:Investment:Fidelity:Cash  -22.43 USD
+    ofx_fitid: "0123456789024401120120831"
+
+;; date: 2012-08-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-08-31 * "INCOME - DIV - DIVIDEND RECEIVED"
+  Assets:Investment:Fidelity:Cash   22.43 USD
+    date: 2012-08-31
+    ofx_fitid: "0123456789024401220120831"
+    ofx_memo: "DIVIDEND RECEIVED"
+    ofx_type: "INCOME"
+  Income:Fidelity:Dividends:CLCT   -22.43 USD
+
+;; date: 2012-08-31
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: [
+;             {
+;               "amount": "0.16 USD",
+;               "date": "2012-08-31",
+;               "key_value_pairs": {
+;                 "desc": "INTEREST EARNED",
+;                 "ofx_memo": "INTEREST EARNED",
+;                 "ofx_type": "INVBANKTRAN"
+;               },
+;               "source_account": "Assets:Investment:Fidelity:Cash"
+;             }
+;           ]
+2012-08-31 * "INVBANKTRAN - INTEREST EARNED"
+  Assets:Investment:Fidelity:Cash   0.16 USD
+    date: 2012-08-31
+    ofx_fitid: "0123456789024401420120831"
+    ofx_memo: "INTEREST EARNED"
+    ofx_type: "INVBANKTRAN"
+  Expenses:FIXME                   -0.16 USD
+
+;; date: 2012-09-01
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+; features: []
+2012-09-01 * "INCOME - DIV - DIVIDEND RECEIVED"
+  Assets:Investment:Fidelity:Cash   22.50 USD
+    date: 2012-09-01
+    ofx_fitid: "0123456789024801220120901"
+    ofx_memo: "DIVIDEND RECEIVED"
+    ofx_type: "INCOME"
+  Income:Fidelity:Dividends:INTC   -22.50 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:Cash                 18073.98 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:SDRL                 128.00000 SDRL
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 price SDRL                           40.8700000 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:CLCT                 70.57300 CLCT
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 price CLCT                           14.3200000 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:HI                   115.00000 HI
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 price HI                             18.9300000 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:INTC                 100.91100 INTC
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 price INTC                           24.1900000 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:RHT                  50.00000 RHT
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 price RHT                            59.1500000 USD
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 balance Assets:Investment:Fidelity:XIN                  390.90900 XIN
+
+;; date: 2012-09-08
+;; info: {"filename": "<testdata>/fidelity.ofx", "type": "application/x-ofx"}
+
+2012-09-08 price XIN                             2.8200000 USD

--- a/testdata/source/ofx/test_fidelity/journal.beancount
+++ b/testdata/source/ofx/test_fidelity/journal.beancount
@@ -1,0 +1,82 @@
+option "operating_currency" "USD"
+option "conversion_currency" "USD"
+
+1900-01-01 commodity USD
+  name: "US Dollars"
+
+1900-01-01 open Assets:Investment:Fidelity
+  ofx_org: "fidelity.com"
+  ofx_broker_id: "fidelity.com"
+  account_id: "01234567890"
+  ofx_account_type: "securities_and_cash"
+  div_income_account: "Income:Fidelity:Dividends"
+  interest_income_account: "Income:Fidelity:Interest"
+  capital_gains_account: "Income:Fidelity:Capital-Gains"
+  fees_account: "Expenses:Investment:Fidelity:Fees"
+  commission_account: "Expenses:Investment:Fidelity:Commissions"
+
+
+1900-01-01 open Assets:Investment:Fidelity:CLCT
+1900-01-01 open Assets:Investment:Fidelity:Cash
+1900-01-01 open Assets:Investment:Fidelity:HI
+1900-01-01 open Assets:Investment:Fidelity:INTC
+1900-01-01 open Assets:Investment:Fidelity:RHT
+1900-01-01 open Assets:Investment:Fidelity:SDRL
+1900-01-01 open Assets:Investment:Fidelity:SPY
+1900-01-01 open Assets:Investment:Fidelity:XIN
+
+1900-01-01 open Income:Fidelity:Capital-Gains
+1900-01-01 open Income:Fidelity:Capital-Gains:SPY
+1900-01-01 open Income:Fidelity:Dividends
+1900-01-01 open Income:Fidelity:Dividends:CLCT
+1900-01-01 open Income:Fidelity:Dividends:INTC
+1900-01-01 open Income:Fidelity:Dividends:SPY
+1900-01-01 open Income:Fidelity:Dividends:XIN
+1900-01-01 open Income:Fidelity:Interest
+
+1900-01-01 open Expenses:FIXME
+1900-01-01 open Expenses:Investment:Fidelity:Commissions
+1900-01-01 open Expenses:Investment:Fidelity:Fees
+
+1900-01-01 open Equity:Opening-Balances
+
+1900-01-01 * "Opening Balances"
+  Assets:Investment:Fidelity:Cash                  28600.65 USD
+  Assets:Investment:Fidelity:RHT                         50 RHT
+  Equity:Opening-Balances
+
+2012-07-27 * "SELLSTOCK - YOU SOLD"
+  Assets:Investment:Fidelity:SPY                         -8 SPY @ 137.16 USD
+    date: 2012-07-27
+    ofx_fitid: "0123456789020901320120727"
+    ofx_memo: "YOU SOLD"
+    ofx_type: "SELLSTOCK"
+    cleared: TRUE
+  Income:Fidelity:Capital-Gains:SPY
+  Assets:Investment:Fidelity:Cash                   1089.30 USD
+    ofx_fitid: "0123456789020901320120727"
+    cleared: TRUE
+  Expenses:Investment:Fidelity:Commissions           7.9500 USD
+
+2012-08-01 * "SELLSTOCK - IN LIEU OF FRX SHARE"
+  Assets:Investment:Fidelity:SPY                     -0.035 SPY @ 137.142857143 USD
+    date: 2012-08-01
+    ofx_fitid: "0123456789021401420120801"
+    ofx_memo: "IN LIEU OF FRX SHARE"
+    ofx_type: "SELLSTOCK"
+    cleared: TRUE
+  Income:Fidelity:Capital-Gains:SPY
+  Assets:Investment:Fidelity:Cash                      4.80 USD
+    ofx_fitid: "0123456789021401420120801"
+    cleared: TRUE
+
+2012-09-01 * "BUYSTOCK - REINVESTMENT"
+  Assets:Investment:Fidelity:INTC                     0.911 INTC {24.70 USD}
+    date: 2012-09-01
+    ofx_fitid: "0123456789024801120120901"
+    ofx_memo: "REINVESTMENT"
+    ofx_type: "BUYSTOCK"
+    cleared: TRUE
+  Assets:Investment:Fidelity:Cash                    -22.50 USD
+    ofx_fitid: "0123456789024801120120901"
+    cleared: TRUE

--- a/testdata/source/ofx/test_fidelity/training_examples.json
+++ b/testdata/source/ofx/test_fidelity/training_examples.json
@@ -1,0 +1,28 @@
+[
+  [
+    {
+      "amount": "-0.035 SPY",
+      "date": "2012-08-01",
+      "key_value_pairs": {
+        "desc": "IN LIEU OF FRX SHARE",
+        "ofx_memo": "IN LIEU OF FRX SHARE",
+        "ofx_type": "SELLSTOCK"
+      },
+      "source_account": "Assets:Investment:Fidelity:SPY"
+    },
+    "Assets:Investment:Fidelity:Cash"
+  ],
+  [
+    {
+      "amount": "0.911 INTC",
+      "date": "2012-09-01",
+      "key_value_pairs": {
+        "desc": "REINVESTMENT",
+        "ofx_memo": "REINVESTMENT",
+        "ofx_type": "BUYSTOCK"
+      },
+      "source_account": "Assets:Investment:Fidelity:INTC"
+    },
+    "Assets:Investment:Fidelity:Cash"
+  ]
+]

--- a/testdata/source/ofx/test_td_ameritrade/import_results.beancount
+++ b/testdata/source/ofx/test_td_ameritrade/import_results.beancount
@@ -1,6 +1,11 @@
 ;; date: 2017-12-03
 ;; info: {"filename": "<testdata>/td_ameritrade.ofx", "type": "application/x-ofx"}
 
+2017-12-03 balance Assets:Investment:TD-Ameritrade:Cash            0 USD
+
+;; date: 2017-12-03
+;; info: {"filename": "<testdata>/td_ameritrade.ofx", "type": "application/x-ofx"}
+
 2017-12-03 balance Assets:Investment:TD-Ameritrade:AMZN            1 AMZN
 
 ;; date: 2017-12-03


### PR DESCRIPTION
Add a cash balance directive for investment accounts based on the
available cash element using the first matching dated balance entry.

Added additional tests for fidelity.ofx