### PR TITLE
Journal entry filename should have bean in name

### DIFF
--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -120,6 +120,7 @@ set.  The resulting sum must equal 0 within a small tolerance.
 
 """
 
+import os
 import datetime
 import collections
 import itertools
@@ -347,7 +348,8 @@ class PostingDatabase(object):
         }
 
 def is_entry_from_journal(entry: Transaction):
-    return entry.meta and 'filename' in entry.meta
+    return entry.meta and 'filename' in entry.meta \
+        and 'bean' in os.path.basename(entry.meta['filename'])
 
 
 def combine_optional_frozensets(a: Optional[frozenset], b: Optional[frozenset]):


### PR DESCRIPTION
Continuing conversation from [here](https://github.com/jbms/beancount-import/pull/62#issuecomment-667668211)

`beancount.ingest.importer.ImporterProtocol` based importers add `filename` to meta of each transaction.  
Hence they are being classified as journal entry too.  
This causes the beancount-import to pick Imported entry's narration over manually entered transaction's narration.  
Since journal has `.bean/.beancount` extension, that can be an added filter. Statement names almost never contain the word `bean`.  

Tested.

