### PR TITLE
Fix pytest mimetype issues with generic_importer_source_test.py

### DIFF
--- a/beancount_import/source/generic_importer_source.py
+++ b/beancount_import/source/generic_importer_source.py
@@ -48,7 +48,12 @@ class ImporterSource(DescriptionBasedSource):
                            )
         ]
         # filter the valid files for this importer
-        self.files = [f for f in files if self.importer.identify(f)]
+        # handle the fact that importer.identify could raise an exception
+        # instead of returning False, but that ultimately means False for this purpose
+        def try_identify(importer, file):
+            try: return importer.identify(file)
+            except: return False
+        self.files = [f for f in files if try_identify(self.importer, f ) ]
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Without catching these exceptions, I get these errors when running `pytest`:

```
FAILED beancount_import/source/generic_importer_source_test.py::test_source[test_basic] - ValueError: Could not identify the type of file 'testdata/source/generic_importer/test_training_examples/journal.beancount'
FAILED beancount_import/source/generic_importer_source_test.py::test_source[test_invalid] - ValueError: Could not identify the type of file 'testdata/source/generic_importer/test_training_examples/journal.beancount'
FAILED beancount_import/source/generic_importer_source_test.py::test_source[test_training_examples] - ValueError: Could not identify the type of file 'testdata/source/generic_importer/test_training_examples/journal.beancount'
```

The error is coming from:

https://github.com/beancount/beancount/blob/0aed556e5c838e07ef0566af8199c9ae28e9a639/beancount/utils/file_type.py#L68

It's not clear to me why this isn't cropping up for other people. I would be happy to fix in a different way, I just couldn't test my other PR properly fully without fixing this.

This is on macOS 10.15.6 Catalina with Python 3.7.4.

With this combination of dependencies:
```
beancount==2.3.2
python-magic==0.4.18
atomicwrites==1.4.0
attrs==20.2.0
beautifulsoup4==4.9.3
bottle==0.12.18
cachetools==4.1.1
certifi==2020.6.20
chardet==3.0.4
click==7.1.2
google-api-core==1.22.4
google-api-python-client==1.12.3
google-auth==1.22.1
google-auth-httplib2==0.0.4
googleapis-common-protos==1.52.0
httplib2==0.18.1
idna==2.10
importlib-metadata==2.0.0
iniconfig==1.1.1
joblib==0.17.0
jsonschema==3.2.0
lxml==4.6.0
nltk==3.5
numpy==1.19.2
packaging==20.4
pathtools==0.1.2
pluggy==0.13.1
ply==3.11
protobuf==3.13.0
py==1.9.0
pyasn1==0.4.8
pyasn1-modules==0.2.8
pyparsing==2.4.7
pyrsistent==0.17.3
pytest==6.1.1
python-dateutil==2.8.1
pytz==2020.1
regex==2020.10.15
requests==2.24.0
rsa==4.6
scikit-learn==0.23.2
scipy==1.5.3
six==1.15.0
soupsieve==2.0.1
threadpoolctl==2.1.0
toml==0.10.1
tornado==6.0.4
tqdm==4.50.2
uritemplate==3.0.1
urllib3==1.25.10
watchdog==0.10.3
zipp==3.3.1
```