### PR TITLE
Amazon enhancements (caching, date filter, groceries support)

### DIFF
--- a/beancount_import/amount_parsing.py
+++ b/beancount_import/amount_parsing.py
@@ -25,18 +25,20 @@ def parse_number(x):
     sign, number_str = parse_possible_negative(x)
     return sign * D(number_str)
 
-def parse_amount(x):
+def parse_amount(x, assumed_currency=None):
     """Parses a number and currency."""
     if not x:
         return None
     sign, amount_str = parse_possible_negative(x)
-    m = re.fullmatch(r'([\$€£])?((?:[0-9](?:,?[0-9])*|(?=\.))(?:\.[0-9]+)?)(?:\s+([A-Z]{3}))?', amount_str)
+    m = re.fullmatch(r'(?:[(][^)]+[)])?\s*([\$€£])?((?:[0-9](?:,?[0-9])*|(?=\.))(?:\.[0-9]+)?)(?:\s+([A-Z]{3}))?', amount_str)
     if m is None:
         raise ValueError('Failed to parse amount from %r' % amount_str)
     if m.group(1):
         currency = {'$': 'USD', '€': 'EUR', '£': 'GBP'}[m.group(1)]
     elif m.group(3):
         currency = m.group(3)
+    elif assumed_currency is not None:
+        currency = assumed_currency
     else:
         raise ValueError('Failed to determine currency from %r' % amount_str)
     number = D(m.group(2))

--- a/beancount_import/source/amazon.py
+++ b/beancount_import/source/amazon.py
@@ -35,6 +35,7 @@ expression like the following to specify the Amazon source:
 
     dict(module='beancount_import.source.amazon',
          directory=os.path.join(journal_dir, 'data/amazon'),
+         pickle_dir=os.path.join(journal_dir, 'data/amazon/.pickle')
          amazon_account='name@domain.com',
          posttax_adjustment_accounts={
              'Gift Card Amount': 'Assets:Gift-Cards:Amazon',
@@ -236,12 +237,21 @@ If you run into an invoice that results in a parse error, you can use the
 `beancount_import.source.amazon_invoice` module, which has a command-line
 interface, to try to debug it.
 
+Caching Parsing Results
+=======================
+
+Parsing the HTML files can be slow, so this module uses the Python pickle 
+module/file format to cache the results of parsing the individual HTML files.
+These cached results are loaded as long as their mtime is more recent than
+the HTML file to load. If you want to enable this funcionality, pass a path
+to the `pickle_dir` parameter when initializing this class.
 """
 
 import collections
 from typing import Dict, List, Tuple, Optional
 import os
 import sys
+import pickle
 
 from beancount.core.data import Transaction, Posting, Balance, Commodity, Price, EMPTY_SET, Directive
 from beancount.core.amount import Amount
@@ -452,12 +462,68 @@ def get_order_ids_seen(journal: JournalEditor,
         order_ids.setdefault(order_id, []).append(entry)
     return order_ids
 
+class AmazonPickler():
+    def __init__( self, pickle_dir: Optional[str] ):
+        self.pickle_dir = pickle_dir
+        if pickle_dir is not None and not os.access(pickle_dir, os.W_OK):
+            raise Exception("Amazon pickled invoice path is not writable: %s" % pickle_dir)
+        
+    @staticmethod
+    def try_get_mtime( path: str ):
+        try:
+            return os.stat(path).st_mtime
+        except:
+            return None
+
+    def _build_pickle_path( self, pickle_dir: str, invoice_path: str ):
+        invoice_dir, invoice_file = os.path.split(invoice_path)
+        pickle_file = invoice_file.replace(".html", ".order.p")
+        return os.path.join(pickle_dir, pickle_file)
+
+    def load( self, results: SourceResults, invoice_path: str ):
+        if not self.pickle_dir: return None
+
+        pickle_path = self._build_pickle_path( self.pickle_dir, invoice_path )
+
+        try:
+            invoice_mtime = AmazonPickler.try_get_mtime( invoice_path )
+            pickle_mtime  = AmazonPickler.try_get_mtime( pickle_path  )
+
+            if invoice_mtime is None or pickle_mtime is None: return None
+            if pickle_mtime < invoice_mtime: return None
+
+            with open(pickle_path, "rb") as f:
+                return pickle.load( f )
+        except:
+            results.add_error('Failed to load pickled invoice %s: %s' % (
+                        pickle_path, sys.exc_info()))
+
+    def dump( self, results: SourceResults, invoice_path: str, invoice: Optional[Order]):
+        if not self.pickle_dir: return None
+        if not invoice: return None
+
+        try:
+            pickle_path = self._build_pickle_path( self.pickle_dir, invoice_path )
+
+            if invoice is None:
+                # remove existing pickles if invoice couldn't be parsed
+                pickle_mtime = AmazonPickler.try_get_mtime( pickle_path ) 
+                if pickle_mtime: os.remove( pickle_path )
+                return
+
+            with open(pickle_path, "wb") as f:
+                return pickle.dump( invoice, f )
+
+        except:
+            results.add_error('Failed to save pickled invoice %s: %s' % (
+                        pickle_path, sys.exc_info()))
 
 class AmazonSource(Source):
     def __init__(self,
                  directory: str,
                  amazon_account: str,
                  posttax_adjustment_accounts: Dict[str, str] = {},
+                 pickle_dir: str = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.directory = directory
@@ -467,6 +533,7 @@ class AmazonSource(Source):
         self.example_posting_key_extractors[CREDIT_CARD_DESCRIPTION_KEY] = None
         self.example_posting_key_extractors[POSTTAX_DESCRIPTION_KEY] = None
         self.example_transaction_key_extractors[AMAZON_ACCOUNT_KEY] = None
+        self.pickler = AmazonPickler(pickle_dir)
 
         self.invoice_filenames = []  # type: List[Tuple[str, str]]
         for filename in os.listdir(self.directory):
@@ -478,14 +545,19 @@ class AmazonSource(Source):
         self._cached_invoices = {
         }  # type: Dict[str, Tuple[Optional[Order], str]]
 
-    def _get_invoice(self, invoice_filename: str):
+    def _get_invoice(self, results: SourceResults, order_id: str, invoice_filename: str):
         if invoice_filename in self._cached_invoices:
             return self._cached_invoices.get(invoice_filename)
-        path = os.path.realpath(os.path.join(self.directory, invoice_filename))
-        self.log_status('amazon: processing %s' % (path, ))
-        invoice = parse_invoice(path)  # type: Optional[Order]
-        self._cached_invoices[invoice_filename] = invoice, path
-        return invoice, path
+        invoice_path = os.path.realpath(os.path.join(self.directory, invoice_filename))
+
+        invoice = self.pickler.load(results, invoice_path) # type: Optional[Order]
+        if invoice is None:
+            self.log_status('amazon: processing %s: %s' % (order_id, invoice_path, ))
+            invoice = parse_invoice(invoice_path)
+            self.pickler.dump( results, invoice_path, invoice )
+
+        self._cached_invoices[invoice_filename] = invoice, invoice_path
+        return invoice, invoice_path
 
     def prepare(self, journal: JournalEditor, results: SourceResults):
         credit_card_accounts = get_credit_card_accounts(journal)
@@ -500,7 +572,7 @@ class AmazonSource(Source):
         for order_id, invoice_filename in self.invoice_filenames:
             if order_id in order_ids_seen: continue
             try:
-              invoice, path = self._get_invoice(invoice_filename)
+              invoice, path = self._get_invoice(results, order_id, invoice_filename)
             except:
                 results.add_error('Failed to parse invoice %s: %s' % (
                     invoice_filename, sys.exc_info()))

--- a/beancount_import/source/amazon_invoice.py
+++ b/beancount_import/source/amazon_invoice.py
@@ -154,6 +154,7 @@ def parse_shipments(soup) -> List[Shipment]:
         'Service completed',
         'Preparing for Shipment',
         'Not Yet Shipped',
+        'Shipping now'
     }
 
     def is_shipment_header_table(node):

--- a/testdata/source/amazon/111-1120740-1860260.html
+++ b/testdata/source/amazon/111-1120740-1860260.html
@@ -1,0 +1,618 @@
+<html dir=ltr >
+<head>
+
+<style type="text/css">
+
+.displayAddressDiv .displayAddressUL {
+  list-style-type: none;
+  padding: 0%;
+  margin-left: 0%;
+  margin-top: 0%;
+  margin-bottom: 0%;
+  vertical-align: top;
+}
+
+.displayAddressDiv .displayAddressLI {
+ width: 100%;
+}
+
+.displayAddressDiv {
+  vertical-align: top;
+  padding-bottom: 0.5em;
+}
+
+.displayAddressDiv h2 {
+  font-size: 1em;
+  display: inline;
+}
+
+#chooseAddressDiv table {
+  width: 100%;
+}
+
+#chooseAddressDiv td {
+  vertical-align: top;
+}
+
+.enterAddressFieldLabel {
+  text-align: right;
+}
+
+.enterAddressFieldICAMLabel {
+  vertical-align: middle;
+  max-width: 200px;
+}
+
+.enterAddressFieldICAMLong {
+  width: 386px;
+}
+
+.enterAddressFieldICAMShort {
+  width: 200px;
+}
+
+.enterAddressFormTable td {
+    padding: 2px;
+}
+
+#enterAddressFormDiv input {
+  text-align: left;
+}
+
+#enterAddressFormDiv select {
+  text-align: left;
+  overflow: auto;
+}
+
+div#enterAddressFormDiv {
+  text-align: left;
+}
+
+.enterAddressFieldError {
+  display: block;
+  text-align: left;
+  font-size: .8em;
+  color: red;
+  clear: both;
+}
+
+.enterAddressFieldWarning {
+  display: block;
+  text-align: left;
+  font-size: .8em;
+  color: #e77600;
+  clear: both;
+}
+
+#enterAddressFormDiv .enterAddressFieldSeparatorDiv {
+  clear: both;
+}
+
+.enterAddressFormInputError {
+  border: 1px solid #990000;
+}
+
+#chooseAddressDiv .chooseAddressEditThisAddressButton {
+  margin : 0em .5em;
+}
+
+#chooseAddressDiv .chooseAddressDeleteThisAddressButton {
+  margin : 0em .5em;
+}
+
+#chooseAddressDiv .chooseAddressChooseThisAddressRadioButton {
+  vertical-align: -4em;
+}
+
+#chooseAddressDiv .chooseAddressChooseThisAddressRadioButtonDiv {
+  float : left;
+  height: 100%;
+}
+
+#chooseAddressDiv td {
+ width: 33%;
+}
+
+#chooseAddressDiv .chooseAddressSeparator {
+  margin-top : 1em;
+}
+
+#deleteAddressDiv {
+  color: #a00000;
+  padding-left: 3em;
+}
+
+.enterDeliveryPrefsLabel {
+  text-align: right;
+  vertical-align: middle;
+}
+
+#deliveryPreferences {
+ color: #E47911; 
+ text-decoration: none;
+}
+
+#learnMoreLink a {
+ color: #004B91;
+ text-decoration: none;
+}
+
+#learnMoreLink a:hover, #learnMoreLink a:active, #learnMoreLink a:hover span, #learnMoreLink a:active span {
+ color: #E47911;
+ text-decoration: underline;
+}
+
+#whatsThisLink a {
+ color: #004B91;
+ text-decoration: none;
+}
+
+#whatsThisLink a:hover, #whatsThisLink a:active, #whatsThisLink a:hover span, #whatsThisLink a:active span {
+ color: #E47911;
+ text-decoration: underline;
+}
+
+</style>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<link href='https://images-na.ssl-images-amazon.com/images/G/01/nav2/gamma/websiteGlobalCSS/websiteGlobalCSS-websiteGlobal-10346._V1_.css' type='text/css' rel='stylesheet'>
+<style type="text/css"><!--
+
+.sans, .small, .h1, .h3color, .big, .tiny, .tinyprice, .highlight, .eyebrow,
+    a:active, a:visited, a:link, div.unified_widget p.seeMore,
+    div.unified_widget .carat, div.left_nav .carat, div.left_nav, div.left_nav
+    h2, div.left_nav h3, div.left_nav a:link, div.left_nav a:visited,
+    .popover-tiny, .horizontal-search, .horizontal-websearch, .topnav,
+    .topnav-active a:link, .tabon a, .tabon a:visited, .taboff a, .taboff
+    a:visited div.leftnav_popover h2, .signInMsg{
+  font-family: verdana,arial,helvetica,sans-serif;
+}
+.listprice {
+  font-family: arial,verdana,helvetica,sans-serif;
+}
+.price {
+  font-family: arial,verdana,helvetica,sans-serif;
+}
+.serif, .sans, .h1, div.unified_widget .headline{
+  font-size: medium;
+}
+.big {
+  font-size: xx-large;
+}
+.small, .h3color, .highlight, .horizontal-search {
+  font-size: small;
+}
+.signInMsg {
+  font-size: x-small;
+}
+.tiny, .tinyprice, .popover-tiny, .horizontal-websearch {
+  font-size: x-small;
+}
+body, td, th {
+  font-family: verdana,arial,helvetica,sans-serif;
+  font-size: small;
+}
+.eyebrowBackGroundColor {
+  background-color: ;
+}
+div.left_nav, div.left_nav a:link, div.left_nav a:visited {
+  font-family: Arial, sans-serif;
+}
+
+body {
+  color: #000000;
+  margin-top: 0px;
+}
+--></style> 
+
+
+
+  <title>Amazon.com - Order 111-1120740-1860260</title>
+
+</head>
+<body>
+  
+<img src="https://images-na.ssl-images-amazon.com/images/G/01/x-locale/common/amazon-logo-tiny._CB485936298_.gif" width="113" align="left" height="23" border="0" />
+
+<br />
+
+<br clear=\"all\" />
+  <center><b class="h1">
+        Details for Order #<bdi dir="ltr">111-1120740-1860260</bdi>
+  </b><br />
+
+</center><br />
+
+<table width="90%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center">
+  <tr>
+    <td>
+
+
+
+
+
+
+      <table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+
+
+
+
+        <tr><td valign="top" align="left">
+          <b>
+                Order Placed:
+          </b>
+          October 24, 2020
+        </td></tr>
+
+
+        <tr><td valign="top" align="left">
+          <b>Amazon.com order number:</b>
+          111-1120740-1860260
+        </td></tr>
+
+
+        <tr><td valign="top" align="left">
+          <b>Order Total:
+          $0.00</b>
+        </td></tr>
+
+
+      </table>
+      <br />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#000000" align="center">
+  <tr bgcolor="#000000">
+    <td>
+      <table width="100%" border="0" cellspacing="3" cellpadding="0" align="center" bgcolor="#000000">
+        <tr bgcolor="#ffffff">
+          <td valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tr bgcolor="#ffffff">
+                <td>
+                  <b class="sans"><center>
+                  Shipping now
+                  </center></b>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr valign="top">
+                <td width="100%">
+                  <table border="0" cellspacing="0" cellpadding="2" align="right" >
+                    <tr valign="top">
+                      <td align="right" >
+                        &nbsp;
+                      </td>
+                    </tr>
+                  </table>
+                  <table border="0" cellspacing="2" cellpadding="0" width="100%">
+                    <tr valign="top">
+                      <td valign="top">
+                        <b>Items Ordered</b>
+                      </td>
+                      <td align="right" valign="top">
+                        <b>Price</b>
+                      </td>
+                    </tr>
+                    
+
+
+
+
+  <tr>
+  <input type="hidden" name="lmrnovlmsnmwqny" value="1" />
+  <td colspan="1" valign="top">
+    
+    1
+
+    of:
+
+    <i>Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)</i><br />
+
+
+    <span class='tiny'>
+      Sold by: YDM-US (<a href="http://www.amazon.com/gp/help/seller/at-a-glance.html/ref=od_sold_by_link?ie=UTF8&amp;isAmazonFulfilled=1&amp;marketplaceSeller=1&amp;orderID=111-1120740-1860260&amp;seller=AD7B17X8488B7">seller profile</a>)
+  
+  
+  
+  
+    
+    
+    
+    
+    
+    
+    
+    
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br />
+
+      
+
+      <br />
+
+      Condition: New<br />
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+    $24.99<br />
+    
+  </td></tr>
+
+
+
+
+
+  
+
+
+
+
+
+
+                  </table>
+                  <br />
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr>
+                <td>
+                  
+
+<b>
+Shipping Address:
+</b>
+
+
+
+<br />
+
+
+
+
+<br /><b>
+Shipping Speed:
+</b>
+
+
+
+<br />
+One-Day Shipping
+<br />
+
+
+
+
+
+                    
+
+
+
+                </td>
+                <td align="right" >
+                  <table border="0" cellpadding="0" cellspacing="1">
+</table>
+
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<br />
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#000000" align="center">
+  <tr bgcolor="#000000">
+    <td>
+      <table width="100%" border="0" cellspacing="3" cellpadding="0" align="center" bgcolor="#000000">
+        <tr bgcolor="#ffffff">
+          <td valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tr bgcolor="#ffffff">
+                <td>
+                  <b class="sans"><center>Payment information</center></b>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr valign="top">
+                <td width="100%">
+                  <table border="0" cellspacing="0" cellpadding="2" align="right" >
+                    <tr valign="top">
+                      <td align="right" >
+                        <table border="0" cellpadding="0" cellspacing="1">
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Item(s) Subtotal: </td>
+        <td nowrap="nowrap" align="right" >$24.99</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Shipping &amp; Handling:</td>
+        <td nowrap="nowrap" align="right" >$0.00</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Your Coupon Savings:</td>
+        <td nowrap="nowrap" align="right" >-$3.00</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Total before tax:</td>
+        <td nowrap="nowrap" align="right" >$21.99</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Estimated tax to be collected:</td>
+        <td nowrap="nowrap" align="right" >$1.32</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Gift Card Amount:</td>
+        <td nowrap="nowrap" align="right" >-$23.31</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right"><b>Grand Total:</b></td>
+        <td nowrap="nowrap" align="right" ><b>$0.00</b></td>
+    </tr> 
+</table>
+
+                      </td>
+                    </tr>
+                  </table>
+
+                  
+
+
+
+
+<b>Payment Method: </b>
+
+
+<br />
+
+
+    Amazon.com Visa Signature
+    <nobr> | Last digits:  1234</nobr>
+  <br /> 
+
+
+
+
+
+      Gift Card<br />
+ 
+
+
+
+
+
+
+
+                  
+
+<br />
+<b>Billing address</b>
+
+
+
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+
+
+    </td>
+  </tr>
+</table>
+
+<center>
+    
+  <p>To view the status of your order, return to <a href="/gp/css/summary/edit.html?ie=UTF8&orderID=111-1120740-1860260">Order Summary</a>.</p>
+
+</center>
+
+<br />
+
+
+<center class="tiny">
+
+<a href="http://www.amazon.com/gp/help/customer/display.html?ie=UTF8&amp;nodeId=508088" rel="nofollow">Conditions of Use</a>
+|
+<a href="http://www.amazon.com/gp/help/customer/display.html?ie=UTF8&amp;nodeId=468496" rel="nofollow">Privacy Notice</a>
+&copy; 1996-2020, Amazon.com, Inc. or its affiliates
+</center>
+
+</body>
+</html>
+
+

--- a/testdata/source/amazon/114-4993473-6978631.html
+++ b/testdata/source/amazon/114-4993473-6978631.html
@@ -1,0 +1,570 @@
+<html dir=ltr >
+<head>
+  <title>Amazon.com - Order 114-4993473-6978631</title>
+</head>
+<body>
+
+<br />
+
+
+<br clear=\"all\" />
+  <center><b class="h1">
+            Final Details for Order #114-4993473-6978631
+  </b><br />
+
+</center><br />
+
+<table width="90%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center">
+  <tr>
+    <td>
+
+
+
+
+
+
+      <table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+
+
+
+
+        <tr><td valign="top" align="left">
+          <b>
+                Order Placed:
+          </b>
+          September 1, 2020
+        </td></tr>
+
+
+        <tr><td valign="top" align="left">
+          <b>Amazon.com order number:</b>
+          114-4993473-6978631
+        </td></tr>
+
+
+        <tr><td valign="top" align="left">
+          <b>Order Total:
+          $32.05</b>
+        </td></tr>
+
+
+      </table>
+      <br />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#000000" align="center">
+  <tr bgcolor="#000000">
+    <td>
+      <table width="100%" border="0" cellspacing="3" cellpadding="0" align="center" bgcolor="#000000">
+        <tr bgcolor="#ffffff">
+          <td valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tr bgcolor="#ffffff">
+                <td>
+                  <b class="sans"><center>
+                  Shipped on September 1, 2020
+                  </center></b>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr valign="top">
+                <td width="100%">
+                  <table border="0" cellspacing="0" cellpadding="2" align="right" >
+                    <tr valign="top">
+                      <td align="right" >
+                      </td>
+                    </tr>
+                  </table>
+                  <table border="0" cellspacing="2" cellpadding="0" width="100%">
+                    <tr valign="top">
+                      <td valign="top">
+                        <b>Items Ordered</b>
+                      </td>
+                      <td align="right" valign="top">
+                        <b>Price</b>
+                      </td>
+                    </tr>
+                    
+
+
+  <tr>
+  <input type="hidden" name="lljlrqkpmltsqny" value="2 (1.04 lb)" />
+  <td colspan="1" valign="top">
+    
+    2 (1.04 lb)
+
+    of:
+
+    <i>Broccoli Crowns Conventional, 1 Each</i><br />
+
+
+    <span class='tiny'>
+      Sold by: Whole Foods Market 
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br />
+
+      
+
+      <br />
+
+      Condition: New<br />
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+      ($1.69/lb)  
+    $1.76<br />
+    
+  </td></tr>
+
+
+
+
+
+  <tr>
+  <input type="hidden" name="lljlrqkpmlttony" value="2.07 lb" />
+  <td colspan="1" valign="top">
+    
+    2.07 lb
+
+    of:
+
+    <i>Pork Sausage Link Italian Mild Step 1</i><br />
+
+
+    <span class='tiny'>
+      Sold by: Whole Foods Market 
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br />
+
+      
+
+      <br />
+
+      Condition: New<br />
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+      ($6.99/lb)  
+    $14.47<br />
+    
+  </td></tr>
+
+
+  <tr>
+  <input type="hidden" name="lljltppqtoswqny" value="3 (2.32 lb)" />
+  <td colspan="1" valign="top">
+    
+    3 (2.32 lb)
+
+    of:
+
+    <i>Yellow Squash</i><br />
+
+
+    <span class='tiny'>
+      Sold by: Whole Foods Market 
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br />
+
+      
+
+      <br />
+
+      Condition: New<br />
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+      ($1.99/lb)  
+    $4.62<br />
+    
+  </td></tr>
+
+
+
+
+
+  <tr>
+  <input type="hidden" name="lljltppqtotoqny" value="10 (3.85 lb)" />
+  <td colspan="1" valign="top">
+    
+    10 (3.85 lb)
+
+    of:
+
+    <i>Banana Conventional, 1 Each</i><br />
+
+
+    <span class='tiny'>
+      Sold by: Whole Foods Market 
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br />
+
+      
+
+      <br />
+
+      Condition: New<br />
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+      ($0.49/lb)  
+    $1.89<br />
+    
+  </td></tr>
+
+
+  <tr>
+  <input type="hidden" name="lljltujttjprony" value="4 (1.52 lb)" />
+  <td colspan="1" valign="top">
+    
+    4 (1.52 lb)
+
+    of:
+
+    <i>Peach Tree Ripe Organic, 1 Each</i><br />
+
+
+    <span class='tiny'>
+      Sold by: Whole Foods Market 
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br />
+
+      
+
+      <br />
+
+      Condition: New<br />
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+      ($1.99/lb)  
+    $3.02<br />
+    
+  </td></tr>
+
+
+
+
+
+
+
+                  </table>
+                  <br />
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr>
+                <td>
+                  
+
+<b>
+Shipping Address:
+</b>
+
+
+
+<br />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                    
+
+
+<br /><b>
+Shipping Speed:
+</b>
+
+
+
+<br />
+Scheduled delivery
+<br />
+
+
+
+
+
+                    
+
+
+
+                </td>
+                <td align="right" >
+                  <table border="0" cellpadding="0" cellspacing="1">
+</table>
+
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<br />
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#000000" align="center">
+  <tr bgcolor="#000000">
+    <td>
+      <table width="100%" border="0" cellspacing="3" cellpadding="0" align="center" bgcolor="#000000">
+        <tr bgcolor="#ffffff">
+          <td valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tr bgcolor="#ffffff">
+                <td>
+                  <b class="sans"><center>Payment information</center></b>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr valign="top">
+                <td width="100%">
+                  <table border="0" cellspacing="0" cellpadding="2" align="right" >
+                    <tr valign="top">
+                      <td align="right" >
+                        <table border="0" cellpadding="0" cellspacing="1">
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Item(s) Subtotal: </td>
+        <td nowrap="nowrap" align="right" >$25.76</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Shipping &amp; Handling:</td>
+        <td nowrap="nowrap" align="right" >$0.00</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Total before tax:</td>
+        <td nowrap="nowrap" align="right" >$25.76</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Estimated tax to be collected:</td>
+        <td nowrap="nowrap" align="right" >$1.29</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Tip (optional):</td>
+        <td nowrap="nowrap" align="right" >5.00</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right"><b>Grand Total:</b></td>
+        <td nowrap="nowrap" align="right" ><b>$32.05</b></td>
+    </tr> 
+</table>
+
+                      </td>
+                    </tr>
+                  </table>
+
+                  
+
+
+
+
+<b>Payment Method: </b>
+
+
+<br />
+
+
+    Amazon.com Visa Signature
+    <nobr> | Last digits:  1234</nobr>
+  <br /> 
+
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tr>
+                <td valign="top">
+                  <div style="text-align:left;"><b>Credit Card transactions&nbsp;</b></div>
+                </td>
+                <td align="right" >
+                  
+
+
+<table border="0" cellpadding="0" cellspacing="1">
+
+
+  
+  <tr valign="top">
+    <td  nowrap="nowrap" align="right">
+      Visa ending in 1234:&nbsp;September 3, 2020:
+    </td>
+    <td nowrap="nowrap" align="right" colspan="2">
+      $5.00
+    </td>
+  </tr>
+  <tr valign="top">
+    <td  nowrap="nowrap" align="right">
+      Visa ending in 1234:&nbsp;September 1, 2020:
+    </td>
+    <td nowrap="nowrap" align="right" colspan="2">
+      $27.05
+    </td>
+  </tr>
+</table>
+
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+
+
+    </td>
+  </tr>
+</table>
+
+</body>
+</html>
+
+

--- a/testdata/source/amazon/test_basic/import_results.beancount
+++ b/testdata/source/amazon/test_basic/import_results.beancount
@@ -541,3 +541,47 @@
   Expenses:FIXME    -27.05 USD
     amazon_credit_card_description: "Visa ending in 1234"
     transaction_date: 2020-09-01
+
+;; date: 2020-10-24
+;; info: {"filename": "<testdata>/111-1120740-1860260.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.32 USD",
+;               "date": "2020-10-24",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "0.00 USD",
+;               "date": "2020-10-24",
+;               "key_value_pairs": {
+;                 "amazon_credit_card_description": [
+;                   "Amazon.com Visa Signature ending in 1234"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-10-24 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "111-1120740-1860260"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"111-1120740-1860260\"], \"path\": \"<testdata>/111-1120740-1860260.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           24.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+    amazon_item_quantity: 1
+    amazon_seller: "YDM-US"
+  Expenses:FIXME:A           -3.00 USD
+    amazon_invoice_description: "Your Coupon Savings"
+  Expenses:FIXME:A            1.32 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -23.31 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Expenses:FIXME              0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2020-10-24

--- a/testdata/source/amazon/test_basic/import_results.beancount
+++ b/testdata/source/amazon/test_basic/import_results.beancount
@@ -447,3 +447,97 @@
   Expenses:FIXME              0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-09-01
+;; info: {"filename": "<testdata>/114-4993473-6978631.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.29 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Broccoli Crowns Conventional, 1 Each",
+;                   "Pork Sausage Link Italian Mild Step 1",
+;                   "Yellow Squash",
+;                   "Banana Conventional, 1 Each",
+;                   "Peach Tree Ripe Organic, 1 Each"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "5.00 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Tip (optional)"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "-5.00 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_credit_card_description": [
+;                   "Visa ending in 1234"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "-27.05 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_credit_card_description": [
+;                   "Visa ending in 1234"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-09-01 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "114-4993473-6978631"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"114-4993473-6978631\"], \"path\": \"<testdata>/114-4993473-6978631.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A    1.76 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Broccoli Crowns Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A   14.47 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Pork Sausage Link Italian Mild Step 1"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A    4.62 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Yellow Squash"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A    1.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Banana Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A    3.02 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Peach Tree Ripe Organic, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A    1.29 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME      5.00 USD
+    amazon_posttax_adjustment: "Tip (optional)"
+  Expenses:FIXME     -5.00 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-03
+  Expenses:FIXME    -27.05 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-01

--- a/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
+++ b/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
@@ -222,3 +222,37 @@
   Liabilities:Credit-Card  -27.05 USD
     amazon_credit_card_description: "Visa ending in 1234"
     transaction_date: 2020-09-01
+
+;; date: 2020-10-24
+;; info: {"filename": "<testdata>/111-1120740-1860260.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.32 USD",
+;               "date": "2020-10-24",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-10-24 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "111-1120740-1860260"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"111-1120740-1860260\"], \"path\": \"<testdata>/111-1120740-1860260.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           24.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+    amazon_item_quantity: 1
+    amazon_seller: "YDM-US"
+  Expenses:FIXME:A           -3.00 USD
+    amazon_invoice_description: "Your Coupon Savings"
+  Expenses:FIXME:A            1.32 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -23.31 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card     0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2020-10-24

--- a/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
+++ b/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
@@ -148,3 +148,77 @@
   Liabilities:Credit-Card     0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-09-01
+;; info: {"filename": "<testdata>/114-4993473-6978631.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.29 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Broccoli Crowns Conventional, 1 Each",
+;                   "Pork Sausage Link Italian Mild Step 1",
+;                   "Yellow Squash",
+;                   "Banana Conventional, 1 Each",
+;                   "Peach Tree Ripe Organic, 1 Each"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "5.00 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Tip (optional)"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-09-01 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "114-4993473-6978631"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"114-4993473-6978631\"], \"path\": \"<testdata>/114-4993473-6978631.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           1.76 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Broccoli Crowns Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A          14.47 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Pork Sausage Link Italian Mild Step 1"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           4.62 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Yellow Squash"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           1.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Banana Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           3.02 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Peach Tree Ripe Organic, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           1.29 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME             5.00 USD
+    amazon_posttax_adjustment: "Tip (optional)"
+  Liabilities:Credit-Card   -5.00 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-03
+  Liabilities:Credit-Card  -27.05 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-01

--- a/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
+++ b/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
@@ -337,3 +337,77 @@
   Liabilities:Credit-Card     0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-09-01
+;; info: {"filename": "<testdata>/114-4993473-6978631.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.29 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Broccoli Crowns Conventional, 1 Each",
+;                   "Pork Sausage Link Italian Mild Step 1",
+;                   "Yellow Squash",
+;                   "Banana Conventional, 1 Each",
+;                   "Peach Tree Ripe Organic, 1 Each"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "5.00 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Tip (optional)"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-09-01 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "114-4993473-6978631"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"114-4993473-6978631\"], \"path\": \"<testdata>/114-4993473-6978631.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           1.76 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Broccoli Crowns Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A          14.47 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Pork Sausage Link Italian Mild Step 1"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           4.62 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Yellow Squash"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           1.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Banana Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           3.02 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Peach Tree Ripe Organic, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           1.29 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME             5.00 USD
+    amazon_posttax_adjustment: "Tip (optional)"
+  Liabilities:Credit-Card   -5.00 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-03
+  Liabilities:Credit-Card  -27.05 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-01

--- a/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
+++ b/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
@@ -411,3 +411,37 @@
   Liabilities:Credit-Card  -27.05 USD
     amazon_credit_card_description: "Visa ending in 1234"
     transaction_date: 2020-09-01
+
+;; date: 2020-10-24
+;; info: {"filename": "<testdata>/111-1120740-1860260.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.32 USD",
+;               "date": "2020-10-24",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-10-24 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "111-1120740-1860260"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"111-1120740-1860260\"], \"path\": \"<testdata>/111-1120740-1860260.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           24.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+    amazon_item_quantity: 1
+    amazon_seller: "YDM-US"
+  Expenses:FIXME:A           -3.00 USD
+    amazon_invoice_description: "Your Coupon Savings"
+  Expenses:FIXME:A            1.32 USD
+    amazon_invoice_description: "Sales Tax"
+  Assets:Gift-Cards:Amazon  -23.31 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card     0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2020-10-24

--- a/testdata/source/amazon/test_prediction/import_results.beancount
+++ b/testdata/source/amazon/test_prediction/import_results.beancount
@@ -252,3 +252,47 @@
   Liabilities:Credit-Card  -27.05 USD
     amazon_credit_card_description: "Visa ending in 1234"
     transaction_date: 2020-09-01
+
+;; date: 2020-10-24
+;; info: {"filename": "<testdata>/111-1120740-1860260.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.32 USD",
+;               "date": "2020-10-24",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "-23.31 USD",
+;               "date": "2020-10-24",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Gift Card Amount"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-10-24 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "111-1120740-1860260"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"111-1120740-1860260\"], \"path\": \"<testdata>/111-1120740-1860260.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A          24.99 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Magnetic USB C Adapter 20Pins Type C Connector, Support USB PD 100W Quick Charge, 10Gb/s Data Transfer and 4K@60 Hz Video Output Compatible with MacBook Pro/Air and More Type C Devices (Grey)"
+    amazon_item_quantity: 1
+    amazon_seller: "YDM-US"
+  Expenses:FIXME:A          -3.00 USD
+    amazon_invoice_description: "Your Coupon Savings"
+  Expenses:FIXME:A           1.32 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME           -23.31 USD
+    amazon_posttax_adjustment: "Gift Card Amount"
+  Liabilities:Credit-Card    0.00 USD
+    amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
+    transaction_date: 2020-10-24

--- a/testdata/source/amazon/test_prediction/import_results.beancount
+++ b/testdata/source/amazon/test_prediction/import_results.beancount
@@ -178,3 +178,77 @@
   Liabilities:Credit-Card    0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-09-01
+;; info: {"filename": "<testdata>/114-4993473-6978631.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "1.29 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Broccoli Crowns Conventional, 1 Each",
+;                   "Pork Sausage Link Italian Mild Step 1",
+;                   "Yellow Squash",
+;                   "Banana Conventional, 1 Each",
+;                   "Peach Tree Ripe Organic, 1 Each"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "5.00 USD",
+;               "date": "2020-09-01",
+;               "key_value_pairs": {
+;                 "amazon_posttax_adjustment": [
+;                   "Tip (optional)"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-09-01 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "114-4993473-6978631"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"114-4993473-6978631\"], \"path\": \"<testdata>/114-4993473-6978631.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A           1.76 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Broccoli Crowns Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A          14.47 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Pork Sausage Link Italian Mild Step 1"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           4.62 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Yellow Squash"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           1.89 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Banana Conventional, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           3.02 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Peach Tree Ripe Organic, 1 Each"
+    amazon_item_quantity: 1
+    amazon_seller: "Whole Foods Market"
+    shipped_date: 2020-09-01
+  Expenses:FIXME:A           1.29 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME             5.00 USD
+    amazon_posttax_adjustment: "Tip (optional)"
+  Liabilities:Credit-Card   -5.00 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-03
+  Liabilities:Credit-Card  -27.05 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-09-01


### PR DESCRIPTION
Several enhancements to the Amazon processing code:

* Caching of HTML parse results as pickle files
* Configuration option to skip invoices before a certain date (which can only act after parsing the HTML)
* Support for grocery orders through Amazon Fresh, Whole Foods, or Prime Now which contain tips (with no currency specified in the HTML) and weighed items with slightly different quantity and price formats

With a hundreds of Amazon files, and a lot of them being excluded due to the date filter (and thus can't be skipped due to existing in my journal), the caching makes a huge difference in startup/processing time.

Hopefully the parsing changes didn't break anything for non-US customers. I haven't encountered any issues, and my changes pass the existing tests, but I'm not sure how much coverage those tests provide.