### PR TITLE
Fix typechecking

### DIFF
--- a/beancount_import/sorted_list.py
+++ b/beancount_import/sorted_list.py
@@ -1,8 +1,10 @@
+from decimal import Decimal
 from typing import TypeVar, Generic, Tuple, Iterable
 import bisect
 import itertools
 
-K = TypeVar('K')
+
+K = TypeVar('K', bound=Decimal)
 V = TypeVar('V')
 
 


### PR DESCRIPTION
Current mypy errors on `sorted(items, key=lambda x: x[0])` because it
requires that the key function return an orderable type. Since currently
the only usage of `SortedList` populates the `K` typevar with
`decimal.Decimal`, the simplest way to reassure mypy is simply to give
that typevar that bound. This of course makes the typing for
`SortedList` somewhat less generic, but the bound can easily be expanded
(e.g. with a `Union` type) in the future if other uses occur.