### PR TITLE
[amazon] fix pretax adjustments not in shipments

### DIFF
--- a/testdata/source/amazon/113-0374995-0086668.html
+++ b/testdata/source/amazon/113-0374995-0086668.html
@@ -1,0 +1,1713 @@
+﻿<html dir="ltr"><head><script async="" src="https://images-na.ssl-images-amazon.com/images/I/31OVaxqP8wL.js" crossorigin="anonymous"></script>
+<script type="text/javascript">var ue_t0=ue_t0||+new Date();</script>
+<script type="text/javascript">
+window.ue_ihb = (window.ue_ihb || window.ueinit || 0) + 1;
+if (window.ue_ihb === 1) {
+var ue_hob=+new Date();
+var ue_id='EZFSVK2FYAW2N3CR7EG6',
+ue_csm = window,
+ue_err_chan = 'jserr-rw',
+ue = {};
+(function(d){var e=d.ue=d.ue||{},f=Date.now||function(){return+new Date};e.d=function(b){return f()-(b?0:d.ue_t0)};e.stub=function(b,a){if(!b[a]){var c=[];b[a]=function(){c.push([c.slice.call(arguments),e.d(),d.ue_id])};b[a].replay=function(b){for(var a;a=c.shift();)b(a[0],a[1],a[2])};b[a].isStub=1}};e.exec=function(b,a){return function(){try{return b.apply(this,arguments)}catch(c){ueLogError(c,{attribution:a||"undefined",logLevel:"WARN"})}}}})(ue_csm);
+
+ue.stub(ue,"log");ue.stub(ue,"onunload");ue.stub(ue,"onflush");
+
+(function(d,e){function h(f,b){if(!(a.ec>a.mxe)&&f){a.ter.push(f);b=b||{};var c=f.logLevel||b.logLevel;c&&c!==k&&c!==m&&c!==n&&c!==p||a.ec++;c&&c!=k||a.ecf++;b.pageURL=""+(e.location?e.location.href:"");b.logLevel=c;b.attribution=f.attribution||b.attribution;a.erl.push({ex:f,info:b})}}function l(a,b,c,e,g){d.ueLogError({m:a,f:b,l:c,c:""+e,err:g,fromOnError:1,args:arguments},g?{attribution:g.attribution,logLevel:g.logLevel}:void 0);return!1}var k="FATAL",m="ERROR",n="WARN",p="DOWNGRADED",a={ec:0,ecf:0,
+pec:0,ts:0,erl:[],ter:[],mxe:50,startTimer:function(){a.ts++;setInterval(function(){d.ue&&a.pec<a.ec&&d.uex("at");a.pec=a.ec},1E4)}};l.skipTrace=1;h.skipTrace=1;h.isStub=1;d.ueLogError=h;d.ue_err=a;e.onerror=l})(ue_csm,window);
+
+ue.stub(ue,"event");ue.stub(ue,"onSushiUnload");ue.stub(ue,"onSushiFlush");
+
+var ue_url='/rd/uedata',
+ue_sid='132-9820800-5370913',
+ue_mid='ATVPDKIKX0DER',
+ue_sn='www.amazon.com',
+ue_furl='fls-na.amazon.com',
+ue_surl='https://unagi-na.amazon.com/1/events/com.amazon.csm.nexusclient.prod',
+ue_navtiming=1,
+ue_fcsn=1,
+ue_isrw=true,
+ue_fpf='//fls-na.amazon.com/1/batch/1/OP/ATVPDKIKX0DER:132-9820800-5370913:EZFSVK2FYAW2N3CR7EG6$uedata=s:',
+ue_qsl=7000,
+ue_rpl_ns=0,
+ue_orct=1,
+ue_int=0,
+ue_adb=1,
+ue_adb_rtla=1,
+ue_ddq=1,
+ue_fps=0,
+ue_rsc=0,
+ue_clf=0,
+ue_pel=0,
+ue_sbuimp=1,
+ue_sclog=false,
+ue_bfd=1000,
+ue_crid=0;
+if (!window.ue_csm) {var ue_csm = window;}
+var ue_viz=function(){(function(c,e,a){function k(b){if(c.ue.viz.length<p&&!l){var a=b.type;b=b.originalEvent;/^focus./.test(a)&&b&&(b.toElement||b.fromElement||b.relatedTarget)||(a=e[m]||("blur"==a||"focusout"==a?"hidden":"visible"),c.ue.viz.push(a+":"+(+new Date-c.ue.t0)),"visible"==a&&(ue.isl&&uex("at"),l=1))}}for(var l=0,f,g,m,n=["","webkit","o","ms","moz"],d=0,p=20,h=0;h<n.length&&!d;h++)if(a=n[h],f=(a?a+"H":"h")+"idden",d="boolean"==typeof e[f])g=a+"visibilitychange",m=(a?a+"V":"v")+"isibilityState";
+k({});d&&e.addEventListener(g,k,0);c.ue&&d&&(c.ue.pageViz={event:g,propHid:f})})(ue_csm,document,window)};
+
+(function(d,k,L){function F(a){return a&&a.replace&&a.replace(/^\s+|\s+$/g,"")}function t(a){return"undefined"===typeof a}function B(a,b){for(var c in b)b[u](c)&&(a[c]=b[c])}function G(a){try{var b=L.cookie.match(RegExp("(^| )"+a+"=([^;]+)"));if(b)return b[2].trim()}catch(c){}}function M(n,b,c){var e=(v||{}).type;2!==e&&1!==e&&(n&&(d.ue_id=a.id=a.rid=n,w=w.replace(/((.*?:){2})(\w+)/,function(a,b){return b+n})),b&&(w=w.replace(/(.*?:)(\w|-)+/,function(a,c){return c+b}),d.ue_sid=b),c&&a.tag("page-source:"+
+c),d.ue_fpf=w)}function N(){var a={};return function(b){b&&(a[b]=1);b=[];for(var c in a)a[u](c)&&b.push(c);return b}}function x(d,b,c,e){e=e||+new C;var h,p;if(b||t(c)){if(d)for(p in h=b?g("t",b)||g("t",b,{}):a.t,h[d]=e,c)c[u](p)&&g(p,b,c[p]);return e}}function g(d,b,c){var e=b&&b!=a.id?a.sc[b]:a;e||(e=a.sc[b]={});"id"===d&&c&&(O=1);return e[d]=c||e[d]}function P(d,b,c,e,h){c="on"+c;var g=b[c];"function"===typeof g?d&&(a.h[d]=g):g=function(){};b[c]=function(a){h?(e(a),g(a)):(g(a),e(a))};b[c]&&(b[c].isUeh=
+1)}function Q(n,b,c,e){function r(b,c){var d=[b],e=0,f={},h,k;c?(d.push("m=1"),f[c]=1):f=a.sc;for(k in f)if(f[u](k)){var r=g("wb",k),l=g("t",k)||{},p=g("t0",k)||a.t0,m;if(c||2==r){r=r?e++:"";d.push("sc"+r+"="+k);for(m in l)3>=m.length&&!t(l[m])&&null!==l[m]&&d.push(m+r+"="+(l[m]-p));d.push("t"+r+"="+l[n]);if(g("ctb",k)||g("wb",k))h=1}}!H&&h&&d.push("ctb=1");return d.join("&")}function p(b,c,f,e){if(b){var g=d.ue_err;d.ue_url&&!e&&b&&0<b.length&&(e=new Image,a.iel.push(e),e.src=b,a.count&&a.count("postbackImageSize",
+b.length));if(w){var h=k.encodeURIComponent;h&&b&&(e=new Image,b=""+d.ue_fpf+h(b)+":"+(+new C-d.ue_t0),a.iel.push(e),e.src=b)}else a.log&&(a.log(b,"uedata",{n:1}),a.ielf.push(b));g&&!g.ts&&g.startTimer();a.b&&(g=a.b,a.b="",p(g,c,f,1))}}function z(b){var c=v?v.type:D,d=2==c||a.isBFonMshop,c=c&&!d,e=a.bfini;O||(e&&1<e&&(b+="&bfform=1",c||(a.isBFT=e-1)),d&&(b+="&bfnt=1",a.isBFT=a.isBFT||1),a.ssw&&a.isBFT&&(a.isBFonMshop&&(a.isNRBF=0),t(a.isNRBF)&&(d=a.ssw(a.oid),d.e||t(d.val)||(a.isNRBF=1<d.val?0:1)),
+t(a.isNRBF)||(b+="&nrbf="+a.isNRBF)),a.isBFT&&!a.isNRBF&&(b+="&bft="+a.isBFT));return b}if(!a.paused&&(b||t(c))){for(var m in c)c[u](m)&&g(m,b,c[m]);a.isBFonMshop||x("pc",b,c);m=g("id",b)||a.id;var s=g("id2",b),f=a.url+"?"+n+"&v="+a.v+"&id="+m,H=g("ctb",b)||g("wb",b),y;H&&(f+="&ctb="+H);s&&(f+="&id2="+s);1<d.ueinit&&(f+="&ic="+d.ueinit);if(!("ld"!=n&&"ul"!=n||b&&b!=m)){if("ld"==n){try{k[I]&&k[I].isUeh&&(k[I]=null)}catch(G){}if(k.chrome)for(s=0;s<J.length;s++)R(E,J[s]);(s=L.ue_backdetect)&&s.ue_back&&
+s.ue_back.value++;d._uess&&(y=d._uess());a.isl=1}a._bf&&(f+="&bf="+a._bf());d.ue_navtiming&&h&&(g("ctb",m,"1"),a.isBFonMshop||x("tc",D,D,K));!A||a.isBFonMshop||S||(h&&B(a.t,{na_:h.navigationStart,ul_:h.unloadEventStart,_ul:h.unloadEventEnd,rd_:h.redirectStart,_rd:h.redirectEnd,fe_:h.fetchStart,lk_:h.domainLookupStart,_lk:h.domainLookupEnd,co_:h.connectStart,_co:h.connectEnd,sc_:h.secureConnectionStart,rq_:h.requestStart,rs_:h.responseStart,_rs:h.responseEnd,dl_:h.domLoading,di_:h.domInteractive,de_:h.domContentLoadedEventStart,
+_de:h.domContentLoadedEventEnd,_dc:h.domComplete,ld_:h.loadEventStart,_ld:h.loadEventEnd,ntd:("function"!==typeof A.now||t(K)?0:new C(K+A.now())-new C)+a.t0}),v&&B(a.t,{ty:v.type+a.t0,rc:v.redirectCount+a.t0}),S=1);a.isBFonMshop||B(a.t,{hob:d.ue_hob,hoe:d.ue_hoe});a.ifr&&(f+="&ifr=1")}x(n,b,c,e);c="ld"==n&&b&&g("wb",b);var q,l;c||b&&b!==m||$(b);c||m==a.oid||aa(m,(g("t",b)||{}).tc||+g("t0",b),+g("t0",b));(e=d.ue_mbl)&&e.cnt&&!c&&(f+=e.cnt());c?g("wb",b,2):"ld"==n&&(a.lid=F(m));for(q in a.sc)if(1==
+g("wb",q))break;if(c){if(a.s)return;f=r(f,null)}else e=r(f,null),e!=f&&(e=z(e),a.b=e),y&&(f+=y),f=r(f,b||a.id);f=z(f);if(a.b||c)for(q in a.sc)2==g("wb",q)&&delete a.sc[q];y=0;a._rt&&(f+="&rt="+a._rt());e=k.csa;if(!c&&e)for(l in q=g("t",b)||{},e=e("PageTiming"),q)q[u](l)&&e("mark",ba[l]||l,q[l]);c||(a.s=0,(l=d.ue_err)&&0<l.ec&&l.pec<l.ec&&(l.pec=l.ec,f+="&ec="+l.ec+"&ecf="+l.ecf),y=g("ctb",b),"ld"!==n||b||a.markers||(a.markers={},B(a.markers,g("t",b))),g("t",b,{}));a.tag&&a.tag().length&&(f+="&csmtags="+
+a.tag().join("|"),a.tag=N());l=a.viz||[];(q=l.length)&&(f+="&viz="+l.splice(0,q).join("|"));t(d.ue_pty)||(f+="&pty="+d.ue_pty+"&spty="+d.ue_spty+"&pti="+d.ue_pti);a.tabid&&(f+="&tid="+a.tabid);a.aftb&&(f+="&aftb=1");!a._ui||b&&b!=m||(f+=a._ui());a.a=f;p(f,n,y,c)}}function $(a){var b=k.ue_csm_markers||{},c;for(c in b)b[u](c)&&x(c,a,D,b[c])}function z(a,b,c){c=c||k;if(c[T])c[T](a,b,!1);else if(c[U])c[U]("on"+a,b)}function R(a,b,c){c=c||k;if(c[V])c[V](a,b,!1);else if(c[W])c[W]("on"+a,b)}function X(){function a(){d.onUl()}
+function b(a){return function(){c[a]||(c[a]=1,Q(a))}}var c={},e,g;d.onLd=b("ld");d.onLdEnd=b("ld");d.onUl=b("ul");e={stop:b("os")};k.chrome?(z(E,a),J.push(a)):e[E]=d.onUl;for(g in e)e[u](g)&&P(0,k,g,e[g]);d.ue_viz&&ue_viz();z("load",d.onLd);x("ue")}function aa(g,b,c){var e=d.ue_mbl,h=k.csa,p=h&&h("SPA"),h=h&&h("PageTiming");e&&e.ajax&&e.ajax(b,c);p&&h&&(p("newPage",{requestId:g,transitionType:"soft"}),h("mark","transitionStart",b));a.tag("ajax-transition")}d.ueinit=(d.ueinit||0)+1;var a=d.ue=d.ue||
+{};a.t0=k.aPageStart||d.ue_t0;a.id=d.ue_id;a.url=d.ue_url;a.rid=d.ue_id;a.a="";a.b="";a.h={};a.s=1;a.t={};a.sc={};a.iel=[];a.ielf=[];a.viz=[];a.v="0.214436.0";a.paused=!1;var u="hasOwnProperty",E="beforeunload",I="on"+E,T="addEventListener",V="removeEventListener",U="attachEvent",W="detachEvent",ba={cf:"criticalFeature",af:"aboveTheFold",fn:"functional",fp:"firstPaint",fcp:"firstContentfulPaint",bb:"bodyBegin",be:"bodyEnd",ld:"loaded"},C=k.Date,A=k.performance||k.webkitPerformance,h=(A||{}).timing,
+v=(A||{}).navigation,K=(h||{}).navigationStart,w=d.ue_fpf,O=0,S=0,J=[],D;a.oid=F(a.id);a.lid=F(a.id);a._t0=a.t0;a.tag=N();a.ifr=k.top!==k.self||k.frameElement?1:0;a.markers=null;a.attach=z;a.detach=R;if("000-0000000-8675309"===d.ue_sid){var Y=G("cdn-rid"),Z=G("session-id");Y&&Z&&M(Y,Z,"cdn")}d.uei=X;d.ueh=P;d.ues=g;d.uet=x;d.uex=Q;a.reset=M;a.pause=function(d){a.paused=d};X()})(ue_csm,window,ue_csm.document);
+
+
+
+(function(c){var a=c.ue;a.cv={};a.cv.scopes={};a.count=function(d,c,b){var e={},f=a.cv,g=b&&0===b.c;e.counter=d;e.value=c;e.t=a.d();b&&b.scope&&(f=a.cv.scopes[b.scope]=a.cv.scopes[b.scope]||{},e.scope=b.scope);if(void 0===c)return f[d];f[d]=c;d=0;b&&b.bf&&(d=1);ue_csm.ue_sclog||!a.clog||0!==d||g?a.log&&a.log(e,"csmcount",{c:1,bf:d}):a.clog(e,"csmcount",{bf:d})};a.count("baselineCounter2",1);a&&a.event&&(a.event({requestId:c.ue_id||"rid",server:c.ue_sn||"sn",obfuscatedMarketplaceId:c.ue_mid||"mid"},
+"csm","csm.CSMBaselineEvent.4"),a.count("nexusBaselineCounter",1,{bf:1}))})(ue_csm);
+
+var ue_hoe=+new Date();
+}
+</script>
+<!-- u -->
+
+
+<style type="text/css">
+
+.displayAddressDiv .displayAddressUL {
+  list-style-type: none;
+  padding: 0%;
+  margin-left: 0%;
+  margin-top: 0%;
+  margin-bottom: 0%;
+  vertical-align: top;
+}
+
+.displayAddressDiv .displayAddressLI {
+ width: 100%;
+}
+
+.displayAddressDiv {
+  vertical-align: top;
+  padding-bottom: 0.5em;
+}
+
+.displayAddressDiv h2 {
+  font-size: 1em;
+  display: inline;
+}
+
+#chooseAddressDiv table {
+  width: 100%;
+}
+
+#chooseAddressDiv td {
+  vertical-align: top;
+}
+
+.enterAddressFieldLabel {
+  text-align: right;
+}
+
+.enterAddressFieldICAMLabel {
+  vertical-align: middle;
+  max-width: 200px;
+}
+
+.enterAddressFieldICAMLong {
+  width: 386px;
+}
+
+.enterAddressFieldICAMShort {
+  width: 200px;
+}
+
+.enterAddressFormTable td {
+    padding: 2px;
+}
+
+#enterAddressFormDiv input {
+  text-align: left;
+}
+
+#enterAddressFormDiv select {
+  text-align: left;
+  overflow: auto;
+}
+
+div#enterAddressFormDiv {
+  text-align: left;
+}
+
+.enterAddressFieldError {
+  display: block;
+  text-align: left;
+  font-size: .8em;
+  color: red;
+  clear: both;
+}
+
+.enterAddressFieldWarning {
+  display: block;
+  text-align: left;
+  font-size: .8em;
+  color: #e77600;
+  clear: both;
+}
+
+#enterAddressFormDiv .enterAddressFieldSeparatorDiv {
+  clear: both;
+}
+
+.enterAddressFormInputError {
+  border: 1px solid #990000;
+}
+
+#chooseAddressDiv .chooseAddressEditThisAddressButton {
+  margin : 0em .5em;
+}
+
+#chooseAddressDiv .chooseAddressDeleteThisAddressButton {
+  margin : 0em .5em;
+}
+
+#chooseAddressDiv .chooseAddressChooseThisAddressRadioButton {
+  vertical-align: -4em;
+}
+
+#chooseAddressDiv .chooseAddressChooseThisAddressRadioButtonDiv {
+  float : left;
+  height: 100%;
+}
+
+#chooseAddressDiv td {
+ width: 33%;
+}
+
+#chooseAddressDiv .chooseAddressSeparator {
+  margin-top : 1em;
+}
+
+#deleteAddressDiv {
+  color: #a00000;
+  padding-left: 3em;
+}
+
+.enterDeliveryPrefsLabel {
+  text-align: right;
+  vertical-align: middle;
+}
+
+#deliveryPreferences {
+ color: #E47911; 
+ text-decoration: none;
+}
+
+#learnMoreLink a {
+ color: #004B91;
+ text-decoration: none;
+}
+
+#learnMoreLink a:hover, #learnMoreLink a:active, #learnMoreLink a:hover span, #learnMoreLink a:active span {
+ color: #E47911;
+ text-decoration: underline;
+}
+
+#whatsThisLink a {
+ color: #004B91;
+ text-decoration: none;
+}
+
+#whatsThisLink a:hover, #whatsThisLink a:active, #whatsThisLink a:hover span, #whatsThisLink a:active span {
+ color: #E47911;
+ text-decoration: underline;
+}
+
+</style>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<link href="https://images-na.ssl-images-amazon.com/images/G/01/nav2/gamma/websiteGlobalCSS/websiteGlobalCSS-websiteGlobal-10346._V1_.css" type="text/css" rel="stylesheet">
+<style type="text/css"><!--
+
+.sans, .small, .h1, .h3color, .big, .tiny, .tinyprice, .highlight, .eyebrow,
+    a:active, a:visited, a:link, div.unified_widget p.seeMore,
+    div.unified_widget .carat, div.left_nav .carat, div.left_nav, div.left_nav
+    h2, div.left_nav h3, div.left_nav a:link, div.left_nav a:visited,
+    .popover-tiny, .horizontal-search, .horizontal-websearch, .topnav,
+    .topnav-active a:link, .tabon a, .tabon a:visited, .taboff a, .taboff
+    a:visited div.leftnav_popover h2, .signInMsg{
+  font-family: verdana,arial,helvetica,sans-serif;
+}
+.listprice {
+  font-family: arial,verdana,helvetica,sans-serif;
+}
+.price {
+  font-family: arial,verdana,helvetica,sans-serif;
+}
+.serif, .sans, .h1, div.unified_widget .headline{
+  font-size: medium;
+}
+.big {
+  font-size: xx-large;
+}
+.small, .h3color, .highlight, .horizontal-search {
+  font-size: small;
+}
+.signInMsg {
+  font-size: x-small;
+}
+.tiny, .tinyprice, .popover-tiny, .horizontal-websearch {
+  font-size: x-small;
+}
+body, td, th {
+  font-family: verdana,arial,helvetica,sans-serif;
+  font-size: small;
+}
+.eyebrowBackGroundColor {
+  background-color: ;
+}
+div.left_nav, div.left_nav a:link, div.left_nav a:visited {
+  font-family: Arial, sans-serif;
+}
+
+body {
+  color: #000000;
+  margin-top: 0px;
+}
+--></style> 
+
+
+
+  <title>Amazon.com - Order 113-0374995-0086668</title>
+
+<script type="text/javascript">
+window.ue_ihe = (window.ue_ihe || 0) + 1;
+if (window.ue_ihe === 1) {
+(function(s,l){function m(b,e,c){c=c||new Date(+new Date+t);c="expires="+c.toUTCString();n.cookie=b+"="+e+";"+c+";path=/"}function p(b){b+="=";for(var e=n.cookie.split(";"),c=0;c<e.length;c++){for(var a=e[c];" "==a.charAt(0);)a=a.substring(1);if(0===a.indexOf(b))return decodeURIComponent(a.substring(b.length,a.length))}return""}function q(b,e,c){if(!e)return b;-1<b.indexOf("{")&&(b="");for(var a=b.split("&"),f,d=!1,h=!1,g=0;g<a.length;g++)f=a[g].split(":"),f[0]==e?(!c||d?a.splice(g,1):(f[1]=c,a[g]=
+f.join(":")),h=d=!0):2>f.length&&(a.splice(g,1),h=!0);h&&(b=a.join("&"));!d&&c&&(0<b.length&&(b+="&"),b+=e+":"+c);return b}var k=s.ue||{},t=3024E7,n=ue_csm.document||l.document,r=null,d;a:{try{d=l.localStorage;break a}catch(u){}d=void 0}k.count&&k.count("csm.cookieSize",document.cookie.length);k.cookie={get:p,set:m,updateCsmHit:function(b,e,c){try{var a;if(!(a=r)){var f;a:{try{if(d&&d.getItem){f=d.getItem("csm-hit");break a}}catch(k){}f=void 0}a=f||p("csm-hit")||"{}"}a=q(a,b,e);r=a=q(a,"t",+new Date);
+try{d&&d.setItem&&d.setItem("csm-hit",a)}catch(h){}m("csm-hit",a,c)}catch(g){"function"==typeof l.ueLogError&&ueLogError(Error("Cookie manager: "+g.message),{logLevel:"WARN"})}}}})(ue_csm,window);
+
+(function(l,d){function c(b){b="";var c=a.isBFT?"b":"s",d=""+a.oid,f=""+a.lid,g=d;d!=f&&20==f.length&&(c+="a",g+="-"+f);a.tabid&&(b=a.tabid+"+");b+=c+"-"+g;b!=e&&100>b.length&&(e=b,a.cookie?a.cookie.updateCsmHit(m,b+("|"+ +new Date)):document.cookie="csm-hit="+b+("|"+ +new Date)+n+"; path=/")}function p(){e=0}function h(b){!0===d[a.pageViz.propHid]?e=0:!1===d[a.pageViz.propHid]&&c({type:"visible"})}var n="; expires="+(new Date(+new Date+6048E5)).toGMTString(),m="tb",e,a=l.ue||{},k=a.pageViz&&a.pageViz.event&&
+a.pageViz.propHid;a.attach&&(a.attach("click",c),a.attach("keyup",c),k||(a.attach("focus",c),a.attach("blur",p)),k&&(a.attach(a.pageViz.event,h,d),h({})));a.aftb=1})(ue_csm,document);
+
+(function(a){var b=a.alert;window.alert=function(){a.ueLogError&&a.ueLogError({message:"[CSM] Alert invocation detected with argument: "+arguments[0],logLevel:"WARN"});Function.prototype.apply.apply(b,[a,arguments||[]])}})(window);
+
+(function(k,l,g){function m(a){c||(c=b[a.type].id,"undefined"===typeof a.clientX?(e=a.pageX,f=a.pageY):(e=a.clientX,f=a.clientY),2!=c||h&&(h!=e||n!=f)?(r(),d.isl&&l.setTimeout(function(){p("at",d.id)},0)):(h=e,n=f,c=0))}function r(){for(var a in b)b.hasOwnProperty(a)&&d.detach(a,m,b[a].parent)}function s(){for(var a in b)b.hasOwnProperty(a)&&d.attach(a,m,b[a].parent)}function t(){var a="";!q&&c&&(q=1,a+="&ui="+c);return a}var d=k.ue,p=k.uex,q=0,c=0,h,n,e,f,b={click:{id:1,parent:g},mousemove:{id:2,
+parent:g},scroll:{id:3,parent:l},keydown:{id:4,parent:g}};d&&p&&(s(),d._ui=t)})(ue_csm,window,document);
+
+ue_csm.ue.stub(ue,"impression");
+
+ue.stub(ue,"trigger");
+
+}; window.ueinit = window.ue_ihb;
+</script>
+</head>
+<body><script>!function(){function n(n,t){var r=i(n);return t&&(r=r("instance",t)),r}var r=[],c=0,i=function(t){return function(){var n=c++;return r.push([t,[].slice.call(arguments,0),n,{time:Date.now()}]),i(n)}};n._s=r,this.csa=n}();
+            if (window.csa) {
+                csa('Config', {'Application': 'Retail:Prod:www.amazon.com'});
+            }
+    if (window.csa) {
+        csa("Config", {
+            'Events.Namespace': 'csa',
+            'ObfuscatedMarketplaceId': 'ATVPDKIKX0DER',
+            'Events.SushiEndpoint': 'https://unagi.amazon.com/1/events/com.amazon.csm.csa.prod',
+            'CacheDetection.RequestID': "EZFSVK2FYAW2N3CR7EG6",
+            'CacheDetection.Callback': window.ue && ue.reset
+        });
+
+        csa("Events")("setEntity", {
+            page: {
+                requestId: "EZFSVK2FYAW2N3CR7EG6",
+                pageType: "RCXYourAccount",
+                subPageType: "DisplayInvoiceStatus",
+                pageTypeId: ""
+            },
+            session: {id: "132-9820800-5370913"}
+         });
+    }
+!function(n){var e,o,r="splice",i=n.csa,t={},u={},f=n.csa._s,c=0,a={},s={},g={},l=setTimeout,h=Object.keys;function d(n,t){return i(n,t)}function v(n,t){var i=u[n]||{};O(i,t),u[n]=i,l(S,0)}function p(n,t,i){var e=!0;i&&i.buffered&&(e=(g[n]||[]).every(function(n){return!1!==t(n)})),e&&(a[n]||(a[n]=[]),a[n].push(t))}function m(n,t){if(n in s)t(s[n]);else{p(n,function(n){return t(n),!1})}}function b(n){if(i("Errors")("logError",n),t.DEBUG)throw n}function w(){return Math.abs(4294967295*Math.random()|0).toString(36)}function y(n,t){return function(){try{n.apply(this,arguments)}catch(n){b(n.message||n)}}}function S(){for(var n=0;n<f.length;){var t=f[n],i=t[0]in u;if(!i&&!o)return void(c=t.length);i?(f[r](c=n,1),D(t)):n++}}function D(n){var arguments,t=u[n[0]],i=(arguments=n[1])[0];if(!t||!t[i])return b("Undefined function: "+t+"/"+i);e=n[3],u[n[2]]=t[i].apply(t,arguments.slice(1))||{},e=0}function E(){o=1,S()}function O(t,i){h(i).forEach(function(n){t[n]=i[n]})}m("$beforeunload",E),v("Config",{instance:function(n){O(t,n)}}),i.plugin=y(function(n){n(d)}),d.config=t,d.register=v,d.on=p,d.removeListener=function(n,t){var i=a[n];i&&i[r](i.indexOf(t),1)},d.once=m,d.emit=function(n,t,i){for(var e=a[n]||[],o=0;o<e.length;)!1===e[o](t)?e[r](o,1):o++;s[n]=t||{},i&&i.buffered&&(g[n]||(g[n]=[]),100<=g[n].length&&g[n].shift(),g[n].push(t||{}))},d.UUID=function(){return[w(),w(),w(),w()].join("-")},d.time=function(n){var t=e?new Date(e.time):new Date;return"ISO"===n?t.toISOString():t.getTime()},d.error=b,d.exec=y,(d.global=n).csa._s.push=function(n){n[0]in u&&(!f.length||o)?D(n):f[r](c++,0,n)},S(),l(function(){l(E,t.SkipMissingPluginsTimeout||5e3)},1)}("undefined"!=typeof window?window:global);
+csa.plugin(function(e){var n,r,o={},t="localStorage",c="sessionStorage",u="local",a="session";function i(t,n){var r;try{o[n]=!!(r=e.global[t]),r=r||{}}catch(t){o[n]=!(r={})}return r}function s(){n=n||i(t,u),r=r||i(c,a)}function f(t){return t&&t[a]?r:n}e.store=function(t,n,r){try{s();var e=f(r);if(!t)return Object.keys(e);if(!n)return e[t];e[t]=n}catch(t){}},e.storageSupport=function(){return s(),o},e.deleteStored=function(t,n){try{s(),delete f(n)[t]}catch(t){}}});
+csa.plugin(function(s){s.register("Errors",{logError:function(r){s("Metrics",{producerId:"csa",dimensions:{message:r}})("recordMetric","jsError",1)}})});
+csa.plugin(function(r){var o,e=r.global,i=r("Events"),d=e.location,f=e.document,a=((e.performance||{}).navigation||{}).type,t=e.addEventListener,s=r.emit,u={};function n(a,e){var t=!!o,n=(e=e||{}).keepPageAttributes;t&&(s("$beforePageTransition"),s("$pageTransition")),t&&!n&&i("removeEntity","page"),o=r.UUID(),n?u.id=o:u={schemaId:"<ns>.PageEntity.1",id:o,url:d.href,server:d.hostname,path:d.pathname,referrer:f.referrer,title:f.title},Object.keys(a||{}).forEach(function(e){u[e]=a[e]}),i("setEntity",{page:u}),s("$pageChange",u,{buffered:1}),t&&s("$afterPageTransition")}function g(){s("$load"),s("$ready"),s("$afterload")}function l(){s("$ready"),s("$beforeunload"),s("$unload"),s("$afterunload")}d&&f&&(t&&(t("beforeunload",l),t("pagehide",l),"complete"===f.readyState?g():t("load",g)),r.register("SPA",{newPage:n}),n({transitionType:{0:"hard",1:"refresh",2:"back-button"}[a]||"unknown"}))});
+csa.plugin(function(c){var t="Events",e="UNKNOWN",a="id",u="all",n="messageId",i="timestamp",f="producerId",o="application",r="obfuscatedMarketplaceId",s="entities",d="schemaId",l="version",p="attributes",v="<ns>",g=c.config,h=(c.global.location||{}).host,m=g[t+".Namespace"]||"csa_other",I=g.Application||"Other"+(h?":"+h:""),b=c("Transport"),y={},O=function(t,e){Object.keys(t).forEach(e)};function E(n,i,o){O(i,function(t){var e=o===u||(o||{})[t];t in n||(n[t]={version:1,id:i[t][a]||c.UUID()}),U(n[t],i[t],e)})}function U(e,n,i){O(n,function(t){!function(t,e,n){return"string"!=typeof e&&t!==l?c.error("Attribute is not of type string: "+t):!0===n||1===n||(t===a||!!~(n||[]).indexOf(t))}(t,n[t],i)||(e[t]=n[t])})}function N(o,t,r){O(t,function(t){var e=o[t];if(e[d]){var n={},i={};n[a]=e[a],n[f]=e[f]||r,n[d]=e[d],n[l]=e[l]++,n[p]=i,k(n),U(i,e,1),A(i),b("log",n)}})}function k(t){t[i]=function(t){return"number"==typeof t&&(t=new Date(t).toISOString()),t||c.time("ISO")}(t[i]),t[n]=c.UUID(),t[o]=I,t[r]=g.ObfuscatedMarketplaceId||e,t[d]=t[d].replace(v,m)}function A(t){delete t[l],delete t[d],delete t[f]}function D(o){var r={};this.log=function(t,e){var n={},i=(e||{}).ent;return t?"string"!=typeof t[d]?c.error("A valid schema id is required for the event"):(k(t),E(n,y,i),E(n,r,i),E(n,t[s]||{},i),O(n,function(t){A(n[t])}),t[f]=o[f],t[s]=n,void b("log",t)):c.error("The event cannot be undefined")},this.setEntity=function(t){E(r,t,u),N(r,t,o[f])}}c.register(t,{setEntity:function(t){E(y,t,u),N(y,t,"csa")},removeEntity:function(t){delete y[t]},instance:function(t){return new D(t)}})});
+csa.plugin(function(s){var c,l="Transport",d="post",u="preflight",r="csa.cajun.",i="store",a="deleteStored",n="addEventListener",f="sendBeacon",t=0,e=s.config[l+".BufferSize"]||2e3,g=s.config[l+".RetryDelay"]||1500,o=[],h=0,p=[],v=s.global,y=v.document,m=s.config[l+".FlushInterval"]||5e3,E=0;function T(n){if(864e5<s.time()-+new Date(n.timestamp))return s.error("Event is too old: "+n);h<e&&(o.push(n),h++,!E&&t&&(E=setTimeout(R,m)))}function R(){p.forEach(function(t){var e=[];o.forEach(function(n){t.accepts(n)&&e.push(n)}),e.length&&(t.chunks?t.chunks(e).forEach(function(n){S(t,n)}):S(t,e))}),o=[],E=0}function S(t,e){function o(){s[a](r+n)}var n=s.UUID();s[i](r+n,JSON.stringify(e)),[function(n,t,e){var o=v.navigator||{},r=v.cordova||{};if(!o[f]||!n[d])return 0;n[u]&&r&&"ios"===r.platformId&&!c&&((new Image).src=n[u]().url,c=1);var i=n[d](t);if(!i.type&&o[f](i.url,i.body))return e(),1},function(n,t,e){if(!n[d])return 0;var o=n[d](t),r=o.url,i=o.body,c=o.type,u=new XMLHttpRequest,a=0;function f(n,t,e){u.open("POST",n),e&&u.setRequestHeader("Content-Type",e),u.send(t)}return u.onload=function(){u.status<299?e():s.config[l+".XHRRetries"]&&a<3&&setTimeout(function(){f(r,i,c)},++a*g)},f(r,i,c),1}].some(function(n){try{return n(t,e,o)}catch(n){}})}s.once("$afterload",function(){t=1,function(e){(s[i]()||[]).forEach(function(n){if(!n.indexOf(r))try{var t=s[i](n);s[a](n),JSON.parse(t).forEach(e)}catch(n){s.error(n)}})}(T),y&&y[n]&&y[n]("visibilitychange",R,!1),R()}),s.once("$afterunload",function(){t=1,R()}),s.on("$afterPageTransition",function(){h=0}),s.register(l,{log:T,register:function(n){p.push(n)}})});
+csa.plugin(function(n){var r=n.config["Events.SushiEndpoint"];n("Transport")("register",{accepts:function(n){return n.schemaId},post:function(n){var t=n.map(function(n){return{data:n}});return{url:r,body:JSON.stringify({events:t})}},preflight:function(){var n,t=/\/\/(.*?)\//.exec(r);return t&&t[1]&&(n="https://"+t[1]+"/ping"),{url:n}},chunks:function(n){for(var t=[];500<n.length;)t.push(n.splice(0,500));return t.push(n),t}})});
+csa.plugin(function(i){var t,a,o,r,d=i.config["PageViews.ImpressionMinimumTime"]||1e3,e="addEventListener",n="hidden",s="innerHeight",c="innerWidth",g="renderedTo",f=g+"Viewed",m=g+"Meaningful",u=g+"Impressed",l=1,v=2,h=3,p=4,P=5,T="loaded",y=7,I=8,w=i.global,E=i("Events",{producerId:"csa"}),V=w.document,$={},b={},M=P;if(!V||!V[e]||void 0===V[n])return C("PageStateChange.2",{state:"ignored"});function S(e){if(!$[y]){var n;if($[e]=i.time(),e!==h&&e!==T||(t=t||$[e]),t&&M===p)a=a||$[e],(n={})[m]=t-o,n[f]=a-o,C("PageView.4",n),r=r||setTimeout(L,d);if(e!==P&&e!==l&&e!==v||(clearTimeout(r),r=0),e!==l&&e!==v||C("PageRender.3",{transitionType:e===l?"hard":"soft"}),e===y)(n={})[m]=t-o,n[f]=a-o,n[u]=$[e]-o,C("PageImpressed.2",n)}}function C(e,n){b[e]||(n.schemaId="<ns>."+e,E("log",n,{ent:"all"}),b[e]=1)}function H(){0===w[s]&&0===w[c]?(M=I,i("Events")("setEntity",{page:{viewport:"hidden-iframe"}})):M=V[n]?P:p,S(M)}function L(){S(y),r=0}function R(){var e=o?v:l;$={},b={},a=t=0,o=i.time(),S(e),H()}function W(){var e=V.readyState;"interactive"===e&&S(h),"complete"===e&&S(T)}R(),V[e]("visibilitychange",H,!1),V[e]("readystatechange",W,!1),i.on("$afterPageTransition",R),i.once("$load",W),i.on("$timing:loaded",W)});
+csa.plugin(function(c){var n=c.global,u=c.emit,d=5,m="click";function f(n){if(n.id)return"//*[@id='"+n.id+"']";var t=function(n){var t,e=1;for(t=n.previousSibling;t;t=t.previousSibling)t.nodeName===n.nodeName&&(e+=1);return e}(n),e=n.nodeName;return 1!==t&&(e+="["+t+"]"),n.parentNode&&(e=f(n.parentNode)+"/"+e),e}function t(n,t,e){var a=c("Content",{target:e}),i={schemaId:"<ns>.ContentInteraction.1",interaction:n,interactionData:t,messageId:c.UUID()},r=f(e);if(r&&(i.attribution=r),n===m){var o=function(n){for(var t=n,e=t.tagName,a=!1,i=0;i<d;i++){if(!t||!t.parentElement){a=!0;break}e=(t=t.parentElement).tagName+"/"+e}return a||(e=".../"+e),e}(e);o&&(i.interactionData.parentChain=o)}a("log",i),u("$content.interaction",i)}function e(n){c.exec(function(){t(m,{interactionX:""+n.pageX,interactionY:""+n.pageY},n.target)})()}(n.document||{}).documentElement.addEventListener(m,e,{capture:!0,passive:!0})});
+
+
+</script>
+
+  
+  
+
+
+
+
+<img src="https://images-na.ssl-images-amazon.com/images/G/01/x-locale/common/amazon-logo-tiny._CB485936298_.gif" width="113" align="left" height="23" border="0">
+
+<br>
+
+  
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+  
+
+
+
+        
+        
+    
+    
+
+
+
+        
+        
+
+
+
+
+
+
+
+        
+
+
+
+        
+        
+        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+
+
+
+
+
+
+        
+        
+        
+        
+
+
+
+
+
+
+
+
+
+            
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                                                                             
+
+
+
+        
+        
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+
+
+        
+
+  
+
+
+
+
+
+
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+        
+
+        
+
+
+
+
+
+
+
+
+        
+
+
+
+
+
+
+
+
+
+
+<br clear="\&quot;all\&quot;">
+  <center><b class="h1">
+            Final Details for Order #113-0374995-0086668
+  </b><br>
+
+    <script>
+        //works if JS is enabled
+        document.write("<a href='#' onclick='javascript:window.print();'>Print this page for your records.</a>");
+    </script><a href="#" onclick="javascript:window.print();">Print this page for your records.</a>
+</center><br>
+
+<table width="90%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center">
+  <tbody><tr>
+    <td>
+
+
+
+
+
+
+      <table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+
+
+
+
+        <tbody><tr><td valign="top" align="left">
+          <b>
+      Subscribe and Save Order Placed:
+          </b>
+          February 18, 2020
+        </td></tr>
+
+
+        <tr><td valign="top" align="left">
+          <b>Amazon.com order number:</b>
+          113-0374995-0086668
+        </td></tr>
+
+
+        <tr><td valign="top" align="left">
+          <b>Order Total:
+          $6.62</b>
+        </td></tr>
+
+        <tr>
+          <td valign="top" align="left">
+            <b>
+              This order contains Subscribe &amp; Save items.
+            </b>
+          </td>
+        </tr>
+
+      </tbody></table>
+      <br>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#000000" align="center">
+  <tbody><tr bgcolor="#000000">
+    <td>
+      <table width="100%" border="0" cellspacing="3" cellpadding="0" align="center" bgcolor="#000000">
+        <tbody><tr bgcolor="#ffffff">
+          <td valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tbody><tr bgcolor="#ffffff">
+                <td>
+                  <b class="sans"><center>
+                  Shipped on February 28, 2020
+                  </center></b>
+                </td>
+              </tr>
+            </tbody></table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tbody><tr valign="top">
+                <td width="100%">
+                  <table border="0" cellspacing="0" cellpadding="2" align="right">
+                    <tbody><tr valign="top">
+                      <td align="right">
+                        &nbsp;
+                      </td>
+                    </tr>
+                  </tbody></table>
+                  <table border="0" cellspacing="2" cellpadding="0" width="100%">
+                    <tbody><tr valign="top">
+                      <td valign="top">
+                        <b>Items Ordered</b>
+                      </td>
+                      <td align="right" valign="top">
+                        <b>Price</b>
+                      </td>
+                    </tr>
+                    
+
+
+
+
+  <tr>
+  <input type="hidden" name="lgmpqujsplsvwny" value="1">
+  <td colspan="1" valign="top">
+    
+    1
+
+    of:
+
+    <i>Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3</i><br>
+
+
+    <span class="tiny">
+      Sold by: Amazon.com Services LLC
+  
+  
+  
+  
+    
+    
+    
+    
+    
+    
+    
+    
+
+
+
+
+    
+    
+
+
+
+
+    
+    
+<br>
+
+      
+
+      <br>
+
+      Condition: New<br>
+
+
+    </span>
+    
+  </td>
+  <td align="right" valign="top" colspan="2">
+    
+    $7.32<br>
+    
+  </td></tr>
+
+
+
+
+
+  
+
+
+
+
+
+
+                  </tbody></table>
+                  <br>
+                </td>
+              </tr>
+            </tbody></table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tbody><tr>
+                <td>
+                  
+
+<b>
+Shipping Address:
+</b>
+
+
+
+<br>
+
+
+
+<div class="displayAddressDiv">
+<ul class="displayAddressUL">
+<li class="displayAddressLI displayAddressFullName">John Doe</li>
+<li class="displayAddressLI displayAddressAddressLine1">1234 MAIN ST</li>
+<li class="displayAddressLI displayAddressCityStateOrRegionPostalCode">SOMETOWN, XX 12345-6789</li>
+<li class="displayAddressLI displayAddressCountryName">United States</li>
+</ul>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+                    
+
+
+<br><b>
+Shipping Speed:
+</b>
+
+
+
+<br>
+Standard Shipping
+<br>
+
+
+
+
+
+                    
+
+
+
+                </td>
+                <td align="right">
+                  <table border="0" cellpadding="0" cellspacing="1">
+</table>
+
+                </td>
+              </tr>
+            </tbody></table>
+          </td>
+        </tr>
+      </tbody></table>
+    </td>
+  </tr>
+</tbody></table>
+
+<br>
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#000000" align="center">
+  <tbody><tr bgcolor="#000000">
+    <td>
+      <table width="100%" border="0" cellspacing="3" cellpadding="0" align="center" bgcolor="#000000">
+        <tbody><tr bgcolor="#ffffff">
+          <td valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="5">
+              <tbody><tr bgcolor="#ffffff">
+                <td>
+                  <b class="sans"><center>Payment information</center></b>
+                </td>
+              </tr>
+            </tbody></table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tbody><tr valign="top">
+                <td width="100%">
+                  <table border="0" cellspacing="0" cellpadding="2" align="right">
+                    <tbody><tr valign="top">
+                      <td align="right">
+                        <table border="0" cellpadding="0" cellspacing="1">
+    
+    <tbody><tr valign="top">
+        <td nowrap="nowrap" align="right">Item(s) Subtotal: </td>
+        <td nowrap="nowrap" align="right">$7.32</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Shipping &amp; Handling:</td>
+        <td nowrap="nowrap" align="right">$0.00</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Subscribe &amp; Save:</td>
+        <td nowrap="nowrap" align="right">-$1.10</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Total before tax:</td>
+        <td nowrap="nowrap" align="right">$6.22</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">Estimated tax to be collected:</td>
+        <td nowrap="nowrap" align="right">$0.40</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right">&nbsp;</td>
+        <td nowrap="nowrap" align="right">-----</td>
+    </tr> 
+    
+    <tr valign="top">
+        <td nowrap="nowrap" align="right"><b>Grand Total:</b></td>
+        <td nowrap="nowrap" align="right"><b>$6.62</b></td>
+    </tr> 
+</tbody></table>
+
+                      </td>
+                    </tr>
+                  </tbody></table>
+
+                  
+
+
+
+
+<b>Payment Method: </b>
+
+
+<br>
+
+
+    Visa
+    <nobr> | Last digits:  1234</nobr>
+  <br> 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      Gift Card<br>
+ 
+
+
+
+
+
+
+
+                  
+
+<br>
+<b>Billing address</b>
+
+
+
+
+
+
+    
+    
+    
+
+
+
+
+
+
+
+
+
+
+<div class="displayAddressDiv">
+<ul class="displayAddressUL">
+<li class="displayAddressLI displayAddressFullName">John Doe</li>
+<li class="displayAddressLI displayAddressAddressLine1">1234 MAIN ST</li>
+<li class="displayAddressLI displayAddressCityStateOrRegionPostalCode">SOMETOWN, XX 12345-6789</li>
+<li class="displayAddressLI displayAddressCountryName">United States</li>
+</ul>
+</div>
+
+
+
+
+
+
+
+
+
+                </td>
+              </tr>
+            </tbody></table>
+          </td>
+        </tr>
+        <tr>
+          <td bgcolor="#ffffff" valign="top" colspan="2">
+            <table width="100%" border="0" cellspacing="0" cellpadding="2">
+              <tbody><tr>
+                <td valign="top">
+                  <div style="text-align:left;"><b>Credit Card transactions&nbsp;</b></div>
+                </td>
+                <td align="right">
+                  
+
+
+<table border="0" cellpadding="0" cellspacing="1">
+
+
+  
+  <tbody><tr valign="top">
+    <td nowrap="nowrap" align="right">
+      Visa ending in 1234:&nbsp;February 28, 2020:
+    </td>
+    <td nowrap="nowrap" align="right" colspan="2">
+      $6.62
+    </td>
+  </tr>
+</tbody></table>
+
+                </td>
+              </tr>
+            </tbody></table>
+          </td>
+        </tr>
+      </tbody></table>
+    </td>
+  </tr>
+</tbody></table>
+
+
+
+    </td>
+  </tr>
+</tbody></table>
+
+<center>
+
+  <p>To view the status of your order, return to <a href="/gp/css/summary/edit.html?ie=UTF8&amp;orderID=113-0374995-0086668">Order Summary</a>.</p>
+
+</center>
+
+
+
+
+
+<script>   if (typeof uet == 'function') { uet('cf'); } </script> 
+<br>
+
+
+<center class="tiny">
+
+<a href="http://www.amazon.com/gp/help/customer/display.html?ie=UTF8&amp;nodeId=508088" rel="nofollow">Conditions of Use</a>
+|
+<a href="http://www.amazon.com/gp/help/customer/display.html?ie=UTF8&amp;nodeId=468496" rel="nofollow">Privacy Notice</a>
+© 1996-2020, Amazon.com, Inc. or its affiliates
+</center>
+
+
+<!-- whfh-AimQHp46a+/ut+XnGrs+98tAQ/m5dEwJSZuLPNrLzPjwrUVS7ZOraDBYZWMM7znn rid-EZFSVK2FYAW2N3CR7EG6 -->
+
+
+<script>
+(function(e,c){function h(b,a){f.push([b,a])}function g(b,a){if(b){var c=e.head||e.getElementsByTagName("head")[0]||e.documentElement,d=e.createElement("script");d.async="async";d.src=b;d.setAttribute("crossorigin","anonymous");a&&a.onerror&&(d.onerror=a.onerror);a&&a.onload&&(d.onload=a.onload);c.insertBefore(d,c.firstChild)}}function k(){ue.uels=g;for(var b=0;b<f.length;b++){var a=f[b];g(a[0],a[1])}ue.deffered=1}var f=[];c.ue&&(ue.uels=h,c.ue.attach&&c.ue.attach("load",k))})(document,window);
+
+</script>
+<script type="text/javascript">
+(function(g,h){function d(a,d){var b={};if(!e||!f)try{var c=h.sessionStorage;c?a&&("undefined"!==typeof d?c.setItem(a,d):b.val=c.getItem(a)):f=1}catch(g){e=1}e&&(b.e=1);return b}var b=g.ue||{},a="",f,e,c,a=d("csmtid");f?a="NA":a.e?a="ET":(a=a.val,a||(a=b.oid||"NI",d("csmtid",a)),c=d(b.oid),c.e||(c.val=c.val||0,d(b.oid,c.val+1)),b.ssw=d);b.tabid=a})(ue_csm,window);
+
+</script>
+<script type="text/javascript">
+(function(c,l,m){function h(a){if(a)try{if(a.id)return"//*[@id='"+a.id+"']";var b,d=1,e;for(e=a.previousSibling;e;e=e.previousSibling)e.nodeName===a.nodeName&&(d+=1);b=d;var c=a.nodeName;1!==b&&(c+="["+b+"]");a.parentNode&&(c=h(a.parentNode)+"/"+c);return c}catch(f){return"DETACHED"}}function f(a){if(a&&a.getAttribute)return a.getAttribute(k)?a.getAttribute(k):f(a.parentElement)}var k="data-cel-widget",g=!1,d=[];(c.ue||{}).isBF=function(){try{var a=JSON.parse(localStorage["csm-bf"]||"[]"),b=0<=a.indexOf(c.ue_id);
+a.unshift(c.ue_id);a=a.slice(0,20);localStorage["csm-bf"]=JSON.stringify(a);return b}catch(d){return!1}}();c.ue_utils={getXPath:h,getFirstAscendingWidget:function(a,b){c.ue_cel&&c.ue_fem?!0===g?b(f(a)):d.push({element:a,callback:b}):b()},notifyWidgetsLabeled:function(){if(!1===g){g=!0;for(var a=f,b=0;b<d.length;b++)if(d[b].hasOwnProperty("callback")&&d[b].hasOwnProperty("element")){var c=d[b].callback,e=d[b].element;"function"===typeof c&&"function"===typeof a&&c(a(e))}d=null}},extractStringValue:function(a){if("string"===
+typeof a)return a}}})(ue_csm,window,document);
+
+</script>
+<script type="text/javascript">
+window.ue_ibe = (window.ue_ibe || 0) + 1;
+if (window.ue_ibe === 1) {
+if (window.ue && window.ue.uels) {
+    ue.uels("https://images-na.ssl-images-amazon.com/images/I/31OVaxqP8wL.js");
+}
+
+    
+    window.ue_csm.cel_widgets = [
+         {  c: "celwidget"  } , {  id: "fallbacksessionShvl"  } , {  id: "rhf"  } 
+    ];
+
+
+
+ue_csm.ue.exec(function(b){var a=b.ue;if(a&&a.onSushiUnload){if(a.onunload)a.onunload(function(){a.count&&a.count("beforeUnloadNexusCounter",1,{bf:1})});a.onSushiUnload(function(){var c={server:b.ue_sn||"sn"};a.event&&a.event(c,"csm","csm.CSMUnloadBaselineEvent.2")})}},"Nxs-unload-baseline")(ue_csm);
+
+
+(function(a,c){a.ue_cel||(a.ue_cel=function(){function h(a,b){b?b.r=y:b={r:y,c:1};!ue_csm.ue_sclog&&b.clog&&e.clog?e.clog(a,b.ns||n,b):b.glog&&e.glog?e.glog(a,b.ns||n,b):e.log(a,b.ns||n,b)}function l(){var a=b.length;if(0<a){for(var f=[],c=0;c<a;c++){var g=b[c].api;g.ready()?(g.on({ts:e.d,ns:n}),d.push(b[c]),h({k:"mso",n:b[c].name,t:e.d()})):f.push(b[c])}b=f}}function f(){if(!f.executed){for(var a=0;a<d.length;a++)d[a].api.off&&d[a].api.off({ts:e.d,ns:n});q();h({k:"eod",t0:e.t0,t:e.d()},{c:1,il:1});
+f.executed=1;for(a=0;a<d.length;a++)b.push(d[a]);d=[];clearTimeout(t);clearTimeout(v)}}function q(a){h({k:"hrt",t:e.d()},{c:1,il:1,n:a});g=Math.min(k,r*g);z()}function z(){clearTimeout(v);v=setTimeout(function(){q(!0)},g)}function u(){f.executed||q()}var r=1.5,k=c.ue_cel_max_hrt||3E4,b=[],d=[],n=a.ue_cel_ns||"cel",t,v,e=a.ue,m=a.uet,w=a.uex,y=e.rid,g=c.ue_cel_hrt_int||3E3,s=c.requestAnimationFrame||function(a){a()};if(e.isBF)h({k:"bft",t:e.d()});else{"function"==typeof m&&m("bb","csmCELLSframework",
+{wb:1});setTimeout(l,0);e.onunload(f);if(e.onflush)e.onflush(u);t=setTimeout(f,6E5);z();"function"==typeof w&&w("ld","csmCELLSframework",{wb:1});return{registerModule:function(a,c){b.push({name:a,api:c});h({k:"mrg",n:a,t:e.d()});l()},reset:function(a){h({k:"rst",t0:e.t0,t:e.d()});b=b.concat(d);d=[];for(var c=b.length,g=0;g<c;g++)b[g].api.off(),b[g].api.reset();y=a||e.rid;l();clearTimeout(t);t=setTimeout(f,6E5);f.executed=0},timeout:function(a,b){return c.setTimeout(function(){s(function(){f.executed||
+a()})},b)},log:h,off:f}}}())})(ue_csm,window);
+(function(a,c,h){a.ue_pdm||!a.ue_cel||ue.isBF||(a.ue_pdm=function(){function l(){try{var b=window.screen;if(b){var c={w:b.width,aw:b.availWidth,h:b.height,ah:b.availHeight,cd:b.colorDepth,pd:b.pixelDepth};e&&e.w===c.w&&e.h===c.h&&e.aw===c.aw&&e.ah===c.ah&&e.pd===c.pd&&e.cd===c.cd||(e=c,e.t=t(),e.k="sci",s(e))}var g=h.body||{},f=h.documentElement||{},d={w:Math.max(g.scrollWidth||0,g.offsetWidth||0,f.clientWidth||0,f.scrollWidth||0,f.offsetWidth||0),h:Math.max(g.scrollHeight||0,g.offsetHeight||0,f.clientHeight||
+0,f.scrollHeight||0,f.offsetHeight||0)};m&&m.w===d.w&&m.h===d.h||(m=d,m.t=t(),m.k="doi",s(m));n=a.ue_cel.timeout(l,v);y+=1}catch(r){window.ueLogError&&ueLogError(r,{attribution:"csm-cel-page-module",logLevel:"WARN"})}}function f(){k("ebl","default",!1)}function q(){k("efo","default",!0)}function z(){k("ebl","app",!1)}function u(){k("efo","app",!0)}function r(){c.setTimeout(function(){h[D]?k("ebl","pageviz",!1):k("efo","pageviz",!0)},0)}function k(a,b,c){w!==c&&s({k:a,t:t(),s:b},{ff:!0===c?0:1});w=
+c}function b(){g.attach&&(x&&g.attach(p,r,h),A&&P.when("mash").execute(function(a){a&&a.addEventListener&&(a.addEventListener("appPause",z),a.addEventListener("appResume",u))}),g.attach("blur",f,c),g.attach("focus",q,c))}function d(){g.detach&&(x&&g.detach(p,r,h),A&&P.when("mash").execute(function(a){a&&a.removeEventListener&&(a.removeEventListener("appPause",z),a.removeEventListener("appResume",u))}),g.detach("blur",f,c),g.detach("focus",q,c))}var n,t,v,e,m,w=null,y=0,g=a.ue,s=a.ue_cel.log,B=a.uet,
+E=a.uex,x=!!g.pageViz,p=x&&g.pageViz.event,D=x&&g.pageViz.propHid,A=c.P&&c.P.when;"function"==typeof B&&B("bb","csmCELLSpdm",{wb:1});return{on:function(a){v=a.timespan||500;t=a.ts;b();a=c.location;s({k:"pmd",o:a.origin,p:a.pathname,t:t()});l();"function"==typeof E&&E("ld","csmCELLSpdm",{wb:1})},off:function(a){clearTimeout(n);d();g.count&&g.count("cel.PDM.TotalExecutions",y)},ready:function(){return h.body&&a.ue_cel&&a.ue_cel.log},reset:function(){e=m=null}}}(),a.ue_cel&&a.ue_cel.registerModule("page module",
+a.ue_pdm))})(ue_csm,window,document);
+(function(a,c){a.ue_vpm||!a.ue_cel||ue.isBF||(a.ue_vpm=function(){function h(){var a=u(),b={w:c.innerWidth,h:c.innerHeight,x:c.pageXOffset,y:c.pageYOffset};f&&f.w==b.w&&f.h==b.h&&f.x==b.x&&f.y==b.y||(b.t=a,b.k="vpi",f=b,d(f,{clog:1}));q=0;r=u()-a;k+=1}function l(){q||(q=a.ue_cel.timeout(h,z))}var f,q,z,u,r=0,k=0,b=a.ue,d=a.ue_cel.log,n=a.uet,t=a.uex,v=b.attach,e=b.detach;"function"==typeof n&&n("bb","csmCELLSvpm",{wb:1});return{on:function(a){u=a.ts;z=a.timespan||100;h();v&&(v("scroll",l),v("resize",
+l));"function"==typeof t&&t("ld","csmCELLSvpm",{wb:1})},off:function(a){clearTimeout(q);e&&(e("scroll",l),e("resize",l));b.count&&(b.count("cel.VPI.TotalExecutions",k),b.count("cel.VPI.TotalExecutionTime",r),b.count("cel.VPI.AverageExecutionTime",r/k))},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){f=void 0},getVpi:function(){return f}}}(),a.ue_cel&&a.ue_cel.registerModule("viewport module",a.ue_vpm))})(ue_csm,window);
+(function(a,c,h){if(!a.ue_fem&&a.ue_cel&&a.ue_utils){var l=a.ue||{};!l.isBF&&!a.ue_fem&&h.querySelector&&c.getComputedStyle&&[].forEach&&(a.ue_fem=function(){function f(a,b){return a>b?3>a-b:3>b-a}function q(a,b){var e=c.pageXOffset,g=c.pageYOffset,d;a:{try{if(a){var h=a.getBoundingClientRect(),r,l=0===a.offsetWidth&&0===a.offsetHeight;c:{for(var k=a.parentNode,n=h.left||0,p=h.top||0,s=h.width||0,t=h.height||0;k&&k!==document.body;){var m;d:{try{var q=void 0;if(k)var C=k.getBoundingClientRect(),q=
+{x:C.left||0,y:C.top||0,w:C.width||0,h:C.height||0};else q=void 0;m=q;break d}catch(v){}m=void 0}var u=window.getComputedStyle(k),w="hidden"===u.overflow,N=w||"hidden"===u.overflowX,J=w||"hidden"===u.overflowY,z=p+t-1<m.y+1||p+1>m.y+m.h-1;if((n+s-1<m.x+1||n+1>m.x+m.w-1)&&N||z&&J){r=!0;break c}k=k.parentNode}r=!1}d={x:h.left+e||0,y:h.top+g||0,w:h.width||0,h:h.height||0,d:(l||r)|0}}else d=void 0;break a}catch(A){}d=void 0}if(d&&!a.cel_b)a.cel_b=d,x({n:a.getAttribute(y),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,
+x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi",cl:a.className},{clog:1});else{if(e=d)e=a.cel_b,g=d,e=g.d===e.d&&1===g.d?!1:!(f(e.x,g.x)&&f(e.y,g.y)&&f(e.w,g.w)&&f(e.h,g.h)&&e.d===g.d);e&&(a.cel_b=d,x({n:a.getAttribute(y),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi"},{clog:1}))}}function z(b,e){var c;c=b.c?h.getElementsByClassName(b.c):b.id?[h.getElementById(b.id)]:h.querySelectorAll(b.s);b.w=[];for(var d=0;d<c.length;d++){var f=c[d];if(f){if(!f.getAttribute(y)){var r=f.getAttribute("cel_widget_id")||
+(b.id_gen||E)(f,d)||f.id;f.setAttribute(y,r)}b.w.push(f);k(Q,f,e)}}!1===B&&(s++,s===g.length&&(B=!0,a.ue_utils.notifyWidgetsLabeled()))}function u(a,b){p.contains(a)||x({n:a.getAttribute(y),t:b,k:"ewd"},{clog:1})}function r(a){I.length&&ue_cel.timeout(function(){if(m){for(var b=R(),c=!1;R()-b<e&&!c;){for(c=S;0<c--&&0<I.length;){var g=I.shift();T[g.type](g.elem,g.time)}c=0===I.length}U++;r(a)}},0)}function k(a,b,c){I.push({type:a,elem:b,time:c})}function b(a,b){for(var c=0;c<g.length;c++)for(var e=
+g[c].w||[],d=0;d<e.length;d++)k(a,e[d],b)}function d(){K||(K=a.ue_cel.timeout(function(){K=null;var c=w();b(W,c);for(var e=0;e<g.length;e++)k(X,g[e],c);0===g.length&&!1===B&&(B=!0,a.ue_utils.notifyWidgetsLabeled());r(c)},v))}function n(){K||O||(O=a.ue_cel.timeout(function(){O=null;var a=w();b(Q,a);r(a)},v))}function t(){return A&&F&&p&&p.contains&&p.getBoundingClientRect&&w}var v=50,e=4.5,m=!1,w,y="data-cel-widget",g=[],s=0,B=!1,E=function(){},x=a.ue_cel.log,p,D,A,F,G=c.MutationObserver||c.WebKitMutationObserver||
+c.MozMutationObserver,N=!!G,H,C,J="DOMAttrModified",L="DOMNodeInserted",M="DOMNodeRemoved",O,K,I=[],U=0,S=null,W="removedWidget",X="updateWidgets",Q="processWidget",T,V=c.performance||{},R=V.now&&function(){return V.now()}||function(){return Date.now()};"function"==typeof uet&&uet("bb","csmCELLSfem",{wb:1});return{on:function(b){function c(){if(t()){T={removedWidget:u,updateWidgets:z,processWidget:q};if(N){var a={attributes:!0,subtree:!0};H=new G(n);C=new G(d);H.observe(p,a);C.observe(p,{childList:!0,
+subtree:!0});C.observe(D,a)}else A.call(p,J,n),A.call(p,L,d),A.call(p,M,d),A.call(D,L,n),A.call(D,M,n);d()}}p=h.body;D=h.head;A=p.addEventListener;F=p.removeEventListener;w=b.ts;g=a.cel_widgets||[];S=b.bs||5;l.deffered?c():l.attach&&l.attach("load",c);"function"==typeof uex&&uex("ld","csmCELLSfem",{wb:1});m=!0},off:function(){t()&&(C&&(C.disconnect(),C=null),H&&(H.disconnect(),H=null),F.call(p,J,n),F.call(p,L,d),F.call(p,M,d),F.call(D,L,n),F.call(D,M,n));l.count&&l.count("cel.widgets.batchesProcessed",
+U);m=!1},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){g=a.cel_widgets||[]}}}(),a.ue_cel&&a.ue_fem&&a.ue_cel.registerModule("features module",a.ue_fem))}})(ue_csm,window,document);
+(function(a,c,h){!a.ue_mcm&&a.ue_cel&&a.ue_utils&&!a.ue.isBF&&(a.ue_mcm=function(){function l(a,k){var b=a.srcElement||a.target||{},d={k:f,w:(k||{}).ow||(c.body||{}).scrollWidth,h:(k||{}).oh||(c.body||{}).scrollHeight,t:(k||{}).ots||q(),x:a.pageX,y:a.pageY,p:u.getXPath(b),n:b.nodeName};h&&"function"===typeof h.now&&a.timeStamp&&(d.dt=(k||{}).odt||h.now()-a.timeStamp,d.dt=parseFloat(d.dt.toFixed(2)));a.button&&(d.b=a.button);b.href&&(d.r=u.extractStringValue(b.href));b.id&&(d.i=b.id);b.className&&
+b.className.split&&(d.c=b.className.split(/\s+/));z(d,{c:1})}var f="mcm",q,z=a.ue_cel.log,u=a.ue_utils;return{on:function(c){q=c.ts;a.ue_cel_stub&&a.ue_cel_stub.replayModule(f,l);window.addEventListener&&window.addEventListener("mousedown",l,!0)},off:function(a){window.addEventListener&&window.removeEventListener("mousedown",l,!0)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){}}}(),a.ue_cel&&a.ue_cel.registerModule("mouse click module",a.ue_mcm))})(ue_csm,document,window.performance);
+(function(a,c){a.ue_mmm||!a.ue_cel||a.ue.isBF||(a.ue_mmm=function(h){function l(a,b){var c={x:a.pageX||a.x||0,y:a.pageY||a.y||0,t:k()};!b&&x&&(c.t-x.t<z||c.x==x.x&&c.y==x.y)||(x=c,s.push(c))}function f(){if(s.length){y=G.now();for(var a=0;a<s.length;a++){var b=s[a],c=a;p=s[E];D=b;var d=void 0;if(!(d=2>c)){d=void 0;a:if(s[c].t-s[c-1].t>q)d=0;else{for(d=E+1;d<c;d++){var f=p,h=D,k=s[d];A=(h.x-f.x)*(f.y-k.y)-(f.x-k.x)*(h.y-f.y);if(A*A/((h.x-f.x)*(h.x-f.x)+(h.y-f.y)*(h.y-f.y))>u){d=0;break a}}d=1}d=!d}(F=
+d)?E=c-1:B.pop();B.push(b)}g=G.now()-y;v=Math.min(v,g);e=Math.max(e,g);m=(m*w+g)/(w+1);w+=1;n({k:r,e:B,min:Math.floor(1E3*v),max:Math.floor(1E3*e),avg:Math.floor(1E3*m)},{c:1});s=[];B=[];E=0}}var q=100,z=20,u=25,r="mmm1",k,b,d=a.ue,n=a.ue_cel.log,t,v=1E3,e=0,m=0,w=0,y,g,s=[],B=[],E=0,x,p,D,A,F,G=h&&h.now&&h||Date.now&&Date||{now:function(){return(new Date).getTime()}};return{on:function(a){k=a.ts;b=a.ns;d.attach&&d.attach("mousemove",l,c);t=setInterval(f,3E3)},off:function(a){b&&(x&&l(x,!0),f());
+clearInterval(t);d.detach&&d.detach("mousemove",l,c)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){s=[];B=[];E=0;x=null}}}(window.performance),a.ue_cel&&a.ue_cel.registerModule("mouse move module",a.ue_mmm))})(ue_csm,document);
+
+
+}
+</script>
+
+<div id="be" style="display:none;visibility:hidden;"><form name="ue_backdetect"><input name="ue_back" value="2" type="hidden"></form><script type="text/javascript">
+(function(a){var b=document.ue_backdetect;b&&b.ue_back&&a.ue&&(a.ue.bfini=b.ue_back.value);a.uet&&a.uet("be");a.onLdEnd&&(window.addEventListener?window.addEventListener("load",a.onLdEnd,!1):window.attachEvent&&window.attachEvent("onload",a.onLdEnd));a.ueh&&a.ueh(0,window,"load",a.onLd,1);a.ue&&a.ue.tag&&(a.ue_furl?(b=a.ue_furl.replace(/\./g,"-"),a.ue.tag(b)):a.ue.tag("nofls"))})(ue_csm);
+
+
+var ue_pty='RCXYourAccount', ue_spty='DisplayInvoiceStatus', ue_pti='';
+
+</script>
+
+<a href="/rd/uedata?tepes=1&amp;id=EZFSVK2FYAW2N3CR7EG6">v</a>
+<noscript>
+     <img src='/rd/uedata?noscript&amp;id=EZFSVK2FYAW2N3CR7EG6&amp;pty=RCXYourAccount&amp;spty=DisplayInvoiceStatus&amp;pti=' />
+     <img src='//fls-na.amazon.com/1/batch/1/OP/ATVPDKIKX0DER:132-9820800-5370913:EZFSVK2FYAW2N3CR7EG6$uedata=s:%2Frd%2Fuedata%3Fnoscript%26id%3DEZFSVK2FYAW2N3CR7EG6%26pty%3DRCXYourAccount%26spty%3DDisplayInvoiceStatus%26pti%3D:2000' />
+
+</noscript>
+</div>
+<script>
+(function(k,d,h){function f(a,c,b){a&&a.indexOf&&0===a.indexOf("http")&&0!==a.indexOf("https")&&l(s,c,a,b)}function g(a,c,b){a&&a.indexOf&&(location.href.split("#")[0]!=a&&null!==a&&"undefined"!==typeof a||l(t,c,a,b))}function l(a,c,b,e){m[b]||(e=u&&e?n(e):"N/A",d.ueLogError&&d.ueLogError({message:a+c+" : "+b,logLevel:v,stack:"N/A"},{attribution:e}),m[b]=1,p++)}function e(a,c){if(a&&c)for(var b=0;b<a.length;b++)try{c(a[b])}catch(d){}}function q(){return d.performance&&d.performance.getEntriesByType?
+d.performance.getEntriesByType("resource"):[]}function n(a){if(a.id)return"//*[@id='"+a.id+"']";var c;c=1;var b;for(b=a.previousSibling;b;b=b.previousSibling)b.nodeName==a.nodeName&&(c+=1);b=a.nodeName;1!=c&&(b+="["+c+"]");a.parentNode&&(b=n(a.parentNode)+"/"+b);return b}function w(){var a=h.images;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"img",a);g(b,"img",a)})}function x(){var a=h.scripts;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"script",a);g(b,"script",a)})}
+function y(){var a=h.styleSheets;a&&a.length&&e(a,function(a){if(a=a.ownerNode){var b=a.getAttribute("href");f(b,"style",a);g(b,"style",a)}})}function z(){if(A){var a=q();e(a,function(a){f(a.name,a.initiatorType)})}}function B(){e(q(),function(a){g(a.name,a.initiatorType)})}function r(){var a;a=d.location&&d.location.protocol?d.location.protocol:void 0;"https:"==a&&(z(),w(),x(),y(),B(),p<C&&setTimeout(r,D))}var s="[CSM] Insecure content detected ",t="[CSM] Ajax request to same page detected ",v="WARN",
+m={},p=0,D=k.ue_nsip||1E3,C=5,A=1==k.ue_urt,u=!0;ue_csm.ue_disableNonSecure||(d.performance&&d.performance.setResourceTimingBufferSize&&d.performance.setResourceTimingBufferSize(300),r())})(ue_csm,window,document);
+
+</script>
+<script type="text/javascript">
+(function(b,c){var a=c.images;a&&a.length&&b.ue.count("totalImages",a.length)})(ue_csm,document);
+
+</script>
+<script>
+(function(k,c){function l(a,b){return a.filter(function(a){return a.initiatorType==b})}function f(a,c){if(b.t[a]){var g=b.t[a]-b._t0,e=c.filter(function(a){return 0!==a.responseEnd&&m(a)<g}),f=l(e,"script"),h=l(e,"link"),k=l(e,"img"),n=e.map(function(a){return a.name.split("/")[2]}).filter(function(a,b,c){return a&&c.lastIndexOf(a)==b}),q=e.filter(function(a){return a.duration<p}),s=g-Math.max.apply(null,e.map(m))<r|0;"af"==a&&(b._afjs=f.length);return a+":"+[e[d],f[d],h[d],k[d],n[d],q[d],s].join("-")}}
+function m(a){return a.responseEnd-(b._t0-c.timing.navigationStart)}function n(){var a=c[h]("resource"),d=f("cf",a),g=f("af",a),a=f("ld",a);delete b._rt;b._ld=b.t.ld-b._t0;b._art&&b._art();return[d,g,a].join("_")}var p=20,r=50,d="length",b=k.ue,h="getEntriesByType";b._rre=m;b._rt=c&&c.timing&&c[h]&&n})(ue_csm,window.performance);
+
+</script>
+<script type="text/javascript">
+(function(k,l){function K(a){if(a)return a.replace(/^\s+|\s+$/g,"")}function A(a,d){if(!a)return{};var c="INFO"===d.logLevel;a.m&&a.m[n]&&(a=a.m);var b=d.m||d[n]||"",b=a.m&&a.m[n]?b+a.m[n]:a.m&&a.m.target&&a.m.target.tagName?b+("Error handler invoked by "+a.m.target.tagName+" tag"):a.m?b+a.m:a[n]?b+a[n]:b+"Unknown error",b={m:b,name:a.name,type:a.type,csm:L+" "+(a.fromOnError?"onerror":"ueLogError")},e,g,f=0;e=0;var h;g=l.location;b[p]=d[p]||v;d.adb&&(b.adb=d.adb);(e=d[r])&&(b[r]=""+e);if(!c){b[B]=
+d[B]||g&&g.href||"missing";b.f=a.f||a.sourceURL||a.fileName||a.filename||a.m&&a.m.target&&a.m.target.src;b.l=a.l||a.line||a.lineno||a.lineNumber;b.c=a.c?""+a.c:a.c;b.s=[];b.t=k.ue.d();if((c=a.stack||(a.err?a.err.stack:""))&&c.split)for(b.csm+=" stack",e=c.split("\n");f<e.length&&b.s.length<C;)(c=e[f++])&&b.s.push(K(c));else for(b.csm+=" callee",g=D(a.args||arguments,"callee"),e=f=0;g&&f<C;)h=y,g[t]||(c=g.toString())&&c.substr&&(h=0===e?4*y:h,h=1==e?2*y:h,b.s.push(c.substr(0,h)),e++),g=D(g,"caller"),
+f++;!b.f&&0<b.s.length&&(f=b,c=(f||{}).s||[],e=c[1]||"",c=(c[0]||"").match(M)||e.match(N))&&(f.f=c[1],f.l=c[2])}return b}function D(a,d){try{return a[d]}catch(c){}}function E(a,d){if(a&&!(q.ec>q.mxe)){q.ter.push(a);d=d||{};var c=a[p]||d[p];d[p]=c;d[r]=a[r]||d[r];c&&c!==v&&c!==O&&c!==P&&c!==Q||k.ue_err.ec++;c&&c!=v||q.ecf++;z(a,d)}}function z(a,d){if(a){for(var c=A(a,d),b=d.channel||R,e=(window.ue_err?window.ue_err.errorHandlers:null)||[],g=0;g<e.length;g++)"function"==typeof e[g].handler&&e[g].handler(c);
+if(ue.log.isStub&&l[w]&&l[w][x]){e={};e[b]=c;try{var f=l[w][x]({rid:ue.rid,sid:k.ue_sid,mid:k.ue_mid,sn:k.ue_sn,reqs:[e]}),h=l[S],m;if(m=!(h[F]&&h[F](G,f))){var n;if(l[H]){var s=new l[H];s.onerror=u;s.ontimeout=u;s.onprogress=u;s.onload=u;s.timeout=0;n=s}else{var p;if(l[I]){var r=new l[I];p="withCredentials"in r?r:void 0}else p=void 0;n=p}m=n}if(b=m){b.open("POST",G,!0);if(b[J])b[J]("Content-type","text/plain");b.send(f)}}catch(t){}}else k.ue.log(c,b,{nb:1});"function"===typeof q.elh&&q.elh(a,d);
+if(!a.fromOnError){f=l.console||{};b=f.error||f.log||u;h=l[w];m="Error logged with the Track&Report JS errors API(http://tiny/1covqr6l8/wamazindeClieUserJava): ";if(h&&h[x])try{m+=h[x](c)}catch(v){m+="no info provided; converting to string failed"}else m+=c.m;b.apply(f,[m,c])}}}if(k.ue_err){var I="XMLHttpRequest",H="XDomainRequest",S="navigator",F="sendBeacon",x="stringify",w="JSON",p="logLevel",r="attribution",B="pageURL",t="skipTrace",J="setRequestHeader",n="message",u=function(){},G="//"+k.ue_furl+
+"/1/batch/1/OE/",q=k.ue_err,R=k.ue_err_chan||"jserr",v="FATAL",O="ERROR",P="WARN",Q="DOWNGRADED",L="v6",C=20,y=256,N=RegExp(" (?([^ s]*):( d+): d+ )?".split(" ").join(String.fromCharCode(92))),M=/.*@(.*):(\d*)/;A[t]=1;E[t]=1;z[t]=1;(function(){for(var a,d=0;d<(q.erl||[]).length;d++)a=q.erl[d],z(a.ex,a.info);q.erl=[]})();k.ueLogError=E}})(ue_csm,window);
+
+</script>
+<script type="text/javascript">
+(function(c,d){var b=c.ue,a=d.navigator;b&&b.tag&&a&&(a=a.connection||a.mozConnection||a.webkitConnection)&&a.type&&b.tag("netInfo:"+a.type)})(ue_csm,window);
+
+</script>
+<script type="text/javascript">
+(function(c,d){function h(a,b){for(var c=[],d=0;d<a.length;d++){var e=a[d],f=b.encode(e);if(e[k]){var g=b.metaSep,e=e[k],l=b.metaPairSep,h=[],m=void 0;for(m in e)e.hasOwnProperty(m)&&h.push(m+"="+e[m]);e=h.join(l);f+=g+e}c.push(f)}return c.join(b.resourceSep)}function s(a){var b=a[k]=a[k]||{};b[t]||(b[t]=c.ue_mid);b[u]||(b[u]=c.ue_sid);b[f]||(b[f]=c.ue_id);b.csm=1;a="//"+c.ue_furl+"/1/"+a[v]+"/1/OP/"+a[w]+"/"+a[x]+"/"+h([a],y);if(n)try{n.call(d[p],a)}catch(g){c.ue.sbf=1,(new Image).src=a}else(new Image).src=
+a}function q(){g&&g.isStub&&g.replay(function(a,b,c){a=a[0];b=a[k]=a[k]||{};b[f]=b[f]||c;s(a)});l.impression=s;g=null}if(!(1<c.ueinit)){var k="metadata",x="impressionType",v="foresterChannel",w="programGroup",t="marketplaceId",u="session",f="requestId",p="navigator",l=c.ue||{},n=d[p]&&d[p].sendBeacon,r=function(a,b,c,d){return{encode:d,resourceSep:a,metaSep:b,metaPairSep:c}},y=r("","?","&",function(a){return h(a.impressionData,z)}),z=r("/",":",",",function(a){return a.featureName+":"+h(a.resources,
+A)}),A=r(",","@","|",function(a){return a.id}),g=l.impression;n?q():(l.attach("load",q),l.attach("beforeunload",q));try{d.P&&d.P.register&&d.P.register("impression-client",function(){})}catch(B){c.ueLogError(B,{logLevel:"WARN"})}}})(ue_csm,window);
+
+</script>
+<script type="text/javascript">
+ue_csm.ue.exec(function(e,d,a){function b(a,b){return{name:a,getFeatureValue:function(){return void 0!==b|0}}}function h(a,b,c){return{name:a,getFeatureValue:function(){return b===c|0}}}function g(a,b){return{name:a,getFeatureValue:function(){for(var a=0;a<b.length;a++)if(void 0!==b[a])return 1;return 0}}}var f=e.ue||{},c=[b("dall",d.all),b("dcm",d.compatMode),b("xhr",a.XMLHttpRequest),b("qs",d.querySelector),b("ael",d.addEventListener),b("atob",a.atob),g("pjs",[a.callPhantom,a._phantom,a.PhantomEmitter,
+a.__phantomas]),b("njs",a.Buffer),b("cjs",a.emit),b("rhn",a.spawn),b("sel",a.webdriver),g("chrm",[a.domAutomation,a.domAutomationController]),{name:"plg",getFeatureValue:function(){return(void 0!==a.navigator.plugins&&0<a.navigator.plugins.length)|0}}];try{c.push(h("no",a.navigator.onLine,!1))}catch(k){c.push({name:"no",getFeatureValue:function(){return 2}})}f._bf=e.ue.exec(function(){for(var a="",b=0;b<c.length;b++)a+=c[b].name+"_"+c[b].getFeatureValue()+"-";(e.ue||{})._bf=null;return a},"ue.bf");
+f._bf.modules=c;f._bf.mpm=b},"bf")(ue_csm,document,window);
+
+ue_csm.ue.exec(function(c,a){function g(a){a.run(function(e){d.tag("csm-feature-"+a.name+":"+e);d.isl&&c.uex("at")})}if(a.addEventListener)for(var d=c.ue||{},f=[{name:"touch-enabled",run:function(b){var e=function(){a.removeEventListener("touchstart",c,!0);a.removeEventListener("mousemove",d,!0)},c=function(){b("true");e()},d=function(){b("false");e()};a.addEventListener("touchstart",c,!0);a.addEventListener("mousemove",d,!0)}}],b=0;b<f.length;b++)g(f[b])},"csm-features")(ue_csm,window);
+
+</script>
+<!--[if IE 5]>
+<script type='text/javascript'> ue && ue._bf && ue._bf.modules && ue._bf.mpm && ue._bf.modules.push( ue._bf.mpm("cc_ie5", 1) ) </script>
+<![endif]-->
+<!--[if IE 6]>
+<script type='text/javascript'> ue && ue._bf && ue._bf.modules && ue._bf.mpm && ue._bf.modules.push( ue._bf.mpm("cc_ie6", 1) ) </script>
+<![endif]-->
+<!--[if IE 7]>
+<script type='text/javascript'> ue && ue._bf && ue._bf.modules && ue._bf.mpm && ue._bf.modules.push( ue._bf.mpm("cc_ie7", 1) ) </script>
+<![endif]-->
+<!--[if IE 8]>
+<script type='text/javascript'> ue && ue._bf && ue._bf.modules && ue._bf.mpm && ue._bf.modules.push( ue._bf.mpm("cc_ie8", 1) ) </script>
+<![endif]-->
+<!--[if IE 9]>
+<script type='text/javascript'> ue && ue._bf && ue._bf.modules && ue._bf.mpm && ue._bf.modules.push( ue._bf.mpm("cc_ie9", 1) ) </script>
+<![endif]-->
+<script type="text/javascript">
+if (!window.fwcimData) {
+    window.fwcimData = {
+        customerId: 'A39LW1M0P1144G'
+    };
+
+    if (window.P || window.AmazonUIPageJS) {
+        if (window.ue && window.ue.uels) {
+            ue.uels("https://images-na.ssl-images-amazon.com/images/I/71uAHTPElNL.js");
+        }
+    }
+}
+</script>
+<script type="text/javascript">
+ue_csm.ue.exec(function(e,f){var a=e.ue||{},b=a._wlo,d;if(a.ssw){d=a.ssw("CSM_previousURL").val;var c=f.location,b=b?b:c&&c.href?c.href.split("#")[0]:void 0;c=(b||"")===a.ssw("CSM_previousURL").val;!c&&b&&a.ssw("CSM_previousURL",b);d=c?"reload":d?"intrapage-transition":"first-view"}else d="unknown";a._nt=d},"NavTypeModule")(ue_csm,window);
+
+</script>
+<script type="text/javascript">
+var ue_mbl=ue_csm.ue.exec(function(e,a){function l(f){b=f||{};a.AMZNPerformance=b;b.transition=b.transition||{};b.timing=b.timing||{};if(a.csa){var c;b.timing.transitionStart&&(c=b.timing.transitionStart);b.timing.processStart&&(c=b.timing.processStart);c&&(csa("PageTiming")("mark","mobileTransitionStart",c),csa("PageTiming")("mark","transitionStart",c))}e.ue.exec(m,"csm-android-check")()&&b.tags instanceof Array&&(f=-1!=b.tags.indexOf("usesAppStartTime")||b.transition.type?!b.transition.type&&-1<
+b.tags.indexOf("usesAppStartTime")?"warm-start":void 0:"view-transition",f&&(b.transition.type=f));"reload"===d._nt&&e.ue_orct||"intrapage-transition"===d._nt?a.performance&&performance.timing&&performance.timing.navigationStart?b.timing.transitionStart=a.performance.timing.navigationStart:delete b.timing.transitionStart:"undefined"===typeof d._nt&&a.performance&&performance.timing&&performance.timing.navigationStart&&a.history&&"function"===typeof a.History&&"object"===typeof a.history&&history.length&&
+1!=history.length&&(b.timing.transitionStart=a.performance.timing.navigationStart);f=b.transition;c=d._nt?d._nt:void 0;f.subType=c;a.ue&&a.ue.tag&&a.ue.tag("has-AMZNPerformance");d.isl&&a.uex&&uex("at","csm-timing");n()}function p(b){a.ue&&a.ue.count&&a.ue.count("csm-cordova-plugin-failed",1)}function m(){return a.cordova&&a.cordova.platformId&&"android"==a.cordova.platformId}function n(){try{P.register("AMZNPerformance",function(){return b})}catch(a){}}function h(){if(!b)return"";ue_mbl.cnt=null;
+for(var a=b.timing,c=b.transition,a=["mts",k(a.transitionStart),"mps",k(a.processStart),"mtt",c.type,"mtst",c.subType,"mtlt",c.launchType],c="",d=0;d<a.length;d+=2){var e=a[d],g=a[d+1];"undefined"!==typeof g&&(c+="&"+e+"="+g)}return c}function k(a){if("undefined"!==typeof a&&"undefined"!==typeof g)return a-g}function q(a,c){b&&(g=c,b.timing.transitionStart=a,b.transition.type="view-transition",b.transition.subType="ajax-transition",b.transition.launchType="normal",ue_mbl.cnt=h)}var d=e.ue||{},g=e.ue_t0,
+b;if(a.P&&a.P.when&&a.P.register)return a.P.when("CSMPlugin").execute(function(a){a.buildAMZNPerformance&&a.buildAMZNPerformance({successCallback:l,failCallback:p})}),{cnt:h,ajax:q}},"mobile-timing")(ue_csm,window);
+
+</script>
+<script type="text/javascript">
+(function(b){function c(){var d=[];a.log&&a.log.isStub&&a.log.replay(function(a){e(d,a)});a.clog&&a.clog.isStub&&a.clog.replay(function(a){e(d,a)});d.length&&(a._flhs+=1,n(d),p(d))}function g(){a.log&&a.log.isStub&&(a.onflush&&a.onflush.replay&&a.onflush.replay(function(a){a[0]()}),a.onunload&&a.onunload.replay&&a.onunload.replay(function(a){a[0]()}),c())}function e(d,b){var c=b[1],f=b[0],e={};a._lpn[c]=(a._lpn[c]||0)+1;e[c]=f;d.push(e)}function n(b){q&&(a._lpn.csm=(a._lpn.csm||0)+1,b.push({csm:{k:"chk",
+f:a._flhs,l:a._lpn,s:"inln"}}))}function p(a){if(h)a=k(a),b.navigator.sendBeacon(l,a);else{a=k(a);var c=new b[f];c.open("POST",l,!0);c.setRequestHeader&&c.setRequestHeader("Content-type","text/plain");c.send(a)}}function k(a){return JSON.stringify({rid:b.ue_id,sid:b.ue_sid,mid:b.ue_mid,mkt:b.ue_mkt,sn:b.ue_sn,reqs:a})}var f="XMLHttpRequest",q=1===b.ue_ddq,a=b.ue,r=b[f]&&"withCredentials"in new b[f],h=b.navigator&&b.navigator.sendBeacon,l="//"+b.ue_furl+"/1/batch/1/OE/",m=b.ue_fci_ft||5E3;a&&(r||h)&&
+(a._flhs=a._flhs||0,a._lpn=a._lpn||{},a.attach&&(a.attach("beforeunload",g),a.attach("pagehide",g)),m&&b.setTimeout(c,m),a._ffci=c)})(window);
+
+</script>
+<script type="text/javascript">
+ue_csm.ue.exec(function(y,a){function t(){if(d&&f){var a;a:{try{a=d.getItem(g);break a}catch(c){}a=void 0}if(a)return b=a,!0}return!1}function u(){if(a.fetch)fetch(m).then(function(a){if(!a.ok)throw Error(a.statusText);return a.text?a.text():null}).then(function(b){b?(-1<b.indexOf("window.ue_adb_chk = 1")&&(a.ue_adb_chk=1),n()):h()})["catch"](h);else e.uels(m,{onerror:h,onload:n})}function h(){b=k;l();if(f)try{d.setItem(g,b)}catch(a){}}function n(){b=1===a.ue_adb_chk?p:k;l();if(f)try{d.setItem(g,
+b)}catch(c){}}function q(){a.ue_adb_rtla&&c&&0<c.ec&&!1===r&&(c.elh=null,ueLogError({m:"Hit Info",fromOnError:1},{logLevel:"INFO",adb:b}),r=!0)}function l(){e.tag(b);e.isl&&a.uex&&uex("at",b);s&&s.updateCsmHit("adb",b);c&&0<c.ec?q():a.ue_adb_rtla&&c&&(c.elh=q)}function v(){return b}if(a.ue_adb){a.ue_fadb=a.ue_fadb||10;var e=a.ue,k="adblk_yes",p="adblk_no",m="https://m.media-amazon.com/images/G/01/csm/showads.v2.js",b="adblk_unk",d;a:{try{d=a.localStorage;break a}catch(z){}d=void 0}var g="csm:adb",
+c=a.ue_err,s=e.cookie,f=void 0!==a.localStorage,w=Math.random()>1-1/a.ue_fadb,r=!1,x=t();w||!x?u():l();a.ue_isAdb=v;a.ue_isAdb.unk="adblk_unk";a.ue_isAdb.no=p;a.ue_isAdb.yes=k}},"adb")(document,window);
+
+</script>
+<script type="text/javascript">
+ue_csm.ue_unrt = 1500;
+(function(d,b,t){function u(a,g){var c=a.srcElement||a.target||{},b={k:v,t:g.t,dt:g.dt,x:a.pageX,y:a.pageY,p:e.getXPath(c),n:c.nodeName};a.button&&(b.b=a.button);c.type&&(b.ty=c.type);c.href&&(b.r=e.extractStringValue(c.href));c.id&&(b.i=c.id);c.className&&c.className.split&&(b.c=c.className.split(/\s+/));h+=1;e.getFirstAscendingWidget(c,function(a){b.wd=a;d.ue.log(b,r)})}function w(a){if(!x(a.srcElement||a.target)){m+=1;n=!0;var g=f=d.ue.d(),c;p&&"function"===typeof p.now&&a.timeStamp&&(c=p.now()-
+a.timeStamp,c=parseFloat(c.toFixed(2)));s=b.setTimeout(function(){u(a,{t:g,dt:c})},y)}}function z(a){if(a){var b=a.filter(A);a.length!==b.length&&(q=!0,k=d.ue.d(),n&&q&&(k&&f&&d.ue.log({k:B,t:f,m:Math.abs(k-f)},r),l(),q=!1,k=0))}}function A(a){if(!a)return!1;var b="characterData"===a.type?a.target.parentElement:a.target;if(!b||!b.hasAttributes||!b.attributes)return!1;var c={"class":"gw-clock gw-clock-aria s-item-container-height-auto feed-carousel using-mouse kfs-inner-container".split(" "),id:["dealClock",
+"deal_expiry_timer","timer"],role:["timer"]},d=!1;Object.keys(c).forEach(function(a){var e=b.attributes[a]?b.attributes[a].value:"";(c[a]||"").forEach(function(a){-1!==e.indexOf(a)&&(d=!0)})});return d}function x(a){if(!a)return!1;var b=(e.extractStringValue(a.nodeName)||"").toLowerCase(),c=(e.extractStringValue(a.type)||"").toLowerCase(),d=(e.extractStringValue(a.href)||"").toLowerCase();a=(e.extractStringValue(a.id)||"").toLowerCase();var f="checkbox color date datetime-local email file month number password radio range reset search tel text time url week".split(" ");
+if(-1!==["select","textarea","html"].indexOf(b)||"input"===b&&-1!==f.indexOf(c)||"a"===b&&-1!==d.indexOf("http")||-1!==["sitbreaderrightpageturner","sitbreaderleftpageturner","sitbreaderpagecontainer"].indexOf(a))return!0}function l(){n=!1;f=0;b.clearTimeout(s)}function C(){b.ue.onunload(function(){ue.count("armored-cxguardrails.unresponsive-clicks.violations",h);ue.count("armored-cxguardrails.unresponsive-clicks.violationRate",h/m*100||0)})}if(b.MutationObserver&&b.addEventListener&&Object.keys&&
+d&&d.ue&&d.ue.log&&d.ue_unrt&&d.ue_utils){var y=d.ue_unrt,r="cel",v="unr_mcm",B="res_mcm",p=b.performance,e=d.ue_utils,n=!1,f=0,s=0,q=!1,k=0,h=0,m=0;b.addEventListener&&(b.addEventListener("mousedown",w,!0),b.addEventListener("beforeunload",l,!0),b.addEventListener("visibilitychange",l,!0),b.addEventListener("pagehide",l,!0));b.ue&&b.ue.event&&b.ue.onSushiUnload&&b.ue.onunload&&C();(new MutationObserver(z)).observe(t,{childList:!0,attributes:!0,characterData:!0,subtree:!0})}})(ue_csm,window,document);
+
+</script>
+<script type="text/javascript">
+ue_csm.ue.exec(function(g,e){if(e.ue_err){var f="";e.ue_err.errorHandlers||(e.ue_err.errorHandlers=[]);e.ue_err.errorHandlers.push({name:"fctx",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel)if(f=g.getElementsByTagName("html")[0].innerHTML){var b=f.indexOf("var ue_t0=ue_t0||+new Date();");if(-1!==b){var b=f.substr(0,b).split(String.fromCharCode(10)),d=Math.max(b.length-10-1,0),b=b.slice(d,b.length-1);a.fcsmln=d+b.length+1;a.cinfo=a.cinfo||{};for(var c=0;c<b.length;c++)a.cinfo[d+c+1+""]=
+b[c]}b=f.split(String.fromCharCode(10));a.cinfo=a.cinfo||{};if(!(a.f||void 0===a.l||a.l in a.cinfo))for(c=+a.l-1,d=Math.max(c-5,0),c=Math.min(c+5,b.length-1);d<=c;d++)a.cinfo[d+1+""]=b[d]}}})}},"fatals-context")(document,window);
+
+</script>
+<script>var ue_wtc_c = 3;
+ue_csm.ue.exec(function(b,e){function l(){for(var a=0;a<f.length;a++)a:for(var d=s.replace(A,f[a])+g[f[a]]+t,c=arguments,b=0;b<c.length;b++)try{c[b].send(d);break a}catch(e){}g={};f=[];n=0;k=p}function u(){B?l(q):l(C,q)}function v(a,m,c){r++;if(r>w)d.count&&1==r-w&&(d.count("WeblabTriggerThresholdReached",1),b.ue_int&&console.error("Number of max call reached. Data will no longer be send"));else{var h=c||{};h&&-1<h.constructor.toString().indexOf(D)&&a&&-1<a.constructor.toString().indexOf(x)&&m&&-1<
+m.constructor.toString().indexOf(x)?(h=b.ue_id,c&&c.rid&&(h=c.rid),c=h,a=encodeURIComponent(",wl="+a+"/"+m),2E3>a.length+p?(2E3<k+a.length&&u(),void 0===g[c]&&(g[c]="",f.push(c)),g[c]+=a,k+=a.length,n||(n=e.setTimeout(u,E))):b.ue_int&&console.error("Invalid API call. The input provided is over 2000 chars.")):d.count&&(d.count("WeblabTriggerImproperAPICall",1),b.ue_int&&console.error("Invalid API call. The input provided does not match the API protocol i.e ue.trigger(String, String, Object)."))}}function F(){d.trigger&&
+d.trigger.isStub&&d.trigger.replay(function(a){v.apply(this,a)})}function y(){z||(f.length&&l(q),z=!0)}var t=":1234",s="//"+b.ue_furl+"/1/remote-weblab-triggers/1/OE/"+b.ue_mid+":"+b.ue_sid+":PLCHLDR_RID$s:wl-client-id%3DCSMTriger",A="PLCHLDR_RID",E=b.wtt||1E4,p=s.length+t.length,w=b.mwtc||2E3,G=1===e.ue_wtc_c,B=3===e.ue_wtc_c,H=e.XMLHttpRequest&&"withCredentials"in new e.XMLHttpRequest,x="String",D="Object",d=b.ue,g={},f=[],k=p,n,z=!1,r=0,C=function(){return{send:function(a){if(H){var b=new e.XMLHttpRequest;
+b.open("GET",a,!0);G&&(b.withCredentials=!0);b.send()}else throw"";}}}(),q=function(){return{send:function(a){(new Image).src=a}}}();e.encodeURIComponent&&(d.attach&&(d.attach("beforeunload",y),d.attach("pagehide",y)),F(),d.trigger=v)},"client-wbl-trg")(ue_csm,window);
+
+if (ue.trigger) {
+    ue.trigger("UEDATA_AA_SERVERSIDE_ASSIGNMENT_CLIENTSIDE_TRIGGER_190249", "C");
+}
+</script><script type="text/javascript">
+(function(f,b){function g(){try{b.PerformanceObserver&&"function"===typeof b.PerformanceObserver&&(a=new b.PerformanceObserver(function(b){c(b.getEntries())}),a.observe(d))}catch(h){k()}}function m(){for(var h=d.entryTypes,a=0;a<h.length;a++)c(b.performance.getEntriesByType(h[a]))}function c(a){if(a&&Array.isArray(a)){for(var c=0,e=0;e<a.length;e++){var d=l.indexOf(a[e].name);if(-1!==d){var g=Math.round(b.performance.timing.navigationStart+a[e].startTime);f.uet(n[d],void 0,void 0,g);c++}}l.length===
+c&&k()}}function k(){a&&a.disconnect&&"function"===typeof a.disconnect&&a.disconnect()}if("function"===typeof f.uet&&b.performance&&"object"===typeof b.performance&&b.performance.getEntriesByType&&"function"===typeof b.performance.getEntriesByType&&b.performance.timing&&"object"===typeof b.performance.timing&&"number"===typeof b.performance.timing.navigationStart){var d={entryTypes:["paint"]},l=["first-paint","first-contentful-paint"],n=["fp","fcp"],a;try{m(),g()}catch(p){f.ueLogError(p,{logLevel:"ERROR",
+attribution:"performanceMetrics"})}}})(ue_csm,window);
+
+</script>
+<script type="text/javascript">csa.plugin(function(e){var i="transitionStart",n="pageVisible",t="PageTiming",a="visibilitychange",o=e("Events",{producerId:"csa"}),r=(e.global.performance||{}).timing,d=["navigationStart","unloadEventStart","unloadEventEnd","redirectStart","redirectEnd","fetchStart","domainLookupStart","domainLookupEnd","connectStart","connectEnd","secureConnectionStart","requestStart","responseStart","responseEnd","domLoading","domInteractive","domContentLoadedEventStart","domContentLoadedEventEnd","domComplete","loadEventStart","loadEventEnd"],s=e.global.document||{},c=(r||{}).navigationStart,u=c,l={},m=0,v=0,g=e.config[t+".BatchInterval"]||3e3,f=0,p=!0;if(!r||null===c||c<=0||void 0===c)return e.error("Invalid navigation timing data: "+c);function E(t,n){null!=t&&(n=n||e.time(),t===i&&(u=n),l[t]=n,h(),e.emit("$timing:"+t,n))}function S(){!function(){if(f)return;for(var t=0;t<d.length;t++)r[d[t]]&&E(d[t],r[d[t]]);f=1}(),m=1,h(!0)}function h(t){m&&p&&!v&&(v=setTimeout(b,t?0:g))}function b(){0<Object.keys(l).length&&(o("log",{markers:function(t,n){var e={};for(var i in t)t.hasOwnProperty(i)&&(e[i]=Math.max(0,t[i]-n));return e}(l,u),markerTimestamps:function(t){for(var n in t)t.hasOwnProperty(n)&&(t[n]=Math.floor(t[n]));return t}(l),navigationStartTimestamp:u?new Date(u).toISOString():null,schemaId:"<ns>.PageLatency.5"},{ent:{page:["pageType","subPageType","requestId"]}}),l={}),v=0}function y(){return!s.hidden||"visible"===s.visibilityState}("boolean"==typeof s.hidden||"string"==typeof s.visibilityState)&&s.addEventListener&&s.removeEventListener&&((p=y())?(E(n,c),h()):s.addEventListener(a,function t(){(p=y())&&(u=e.time(),s.removeEventListener(a,t),E(n,u),E(i,u),h())})),e.once("$unload",S),e.once("$load",S),e.on("$beforePageTransition",b),e.on("$pageTransition",function(){u=e.time()}),e.register(t,{mark:E})});
+
+csa.plugin(function(e){var m=!!e.config["LCP.elementDedup"],t=!1,n=e("PageTiming"),r=e.global.PerformanceObserver,a=e.global.performance;if(r&&a&&a.timing){var i=e.exec(function(){t||function(o){var l=new r(function(e){var t=e.getEntries();if(0!==t.length){var n=t[t.length-1];if(m&&""!==n.id&&n.element&&"IMG"===n.element.tagName){for(var r={},a=t[0],i=0;i<t.length;i++)t[i].id in r||(""!==t[i].id&&(r[t[i].id]=!0),a.startTime<t[i].startTime&&(a=t[i]));n=a}l.disconnect(),o({startTime:n.startTime,renderTime:n.renderTime,loadTime:n.loadTime})}});try{l.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}}(function(e){e&&(t=!0,n("mark","largestContentfulPaint",Math.floor(e.startTime+o())),e.renderTime&&n("mark","largestContentfulPaint.render",Math.floor(e.renderTime+o())),e.loadTime&&n("mark","largestContentfulPaint.load",Math.floor(e.loadTime+o())))})});e.once("$unload",i),e.once("$load",i),e.register("LargestContentfulPaint",{})}function o(){return a.timing.navigationStart}});
+csa.plugin(function(r){var e=r("Metrics",{producerId:"csa"}),n=r.global.PerformanceObserver;n&&(n=new n(function(r){var t=r.getEntries();if(0===t.length||!t[0].processingStart||!t[0].startTime)return;!function(r){r=r||0,n.disconnect(),0<=r?e("recordMetric","firstInputDelay",r):e("recordMetric","firstInputDelay.invalid",1)}(t[0].processingStart-t[0].startTime)}),function(){try{n.observe({type:"first-input",buffered:!0})}catch(r){}}())});
+csa.plugin(function(u){var a="Metrics";function r(e){var r=e.producerId,n=e.logger,t=n||u("Events",{producerId:r}),i=u.config[a+".BatchInterval"]||3e3,o={},c=(e||{}).dimensions||{},s=0;if(!r&&!n)return u.error("Either a producer id or custom logger must be defined");function d(){Object.keys(o).length&&(t("log",{schemaId:e.schemaId||"<ns>.Metric.3",metrics:o,dimensions:c},e.logOptions||{ent:{page:["pageType","subPageType","requestId"]}}),o={}),s=0}this.recordMetric=function(e,r){o[e]=r,s=s||setTimeout(d,i)},u.on("$beforeunload",d),u.on("$beforePageTransition",d)}new r({producerId:"csa"}).recordMetric("baselineMetricEvent",1),u.register(a,{instance:function(e){return new r(e||{})}})});
+csa.plugin(function(c){var e="Timers",r=(c.global.performance||{}).timing,s=(r||{}).navigationStart||c.time(),u=c.config[e+".BatchInterval"]||3e3;function n(e){var r=(e=e||{}).producerId,n=e.logger,o={},t=0,i=n||c("Events",{producerId:r});if(!r&&!n)return c.error("Either a producer id or custom logger must be defined");function a(){0<Object.keys(o).length&&(i("log",{markers:o,schemaId:e.schemaId||"<ns>.Timer.1"},e.logOptions),o={}),clearTimeout(t),t=0}this.mark=function(e,r){o[e]=(void 0===r?c.time():r)-s,t=t||setTimeout(a,u)},c.once("$beforeunload",a),c.once("$beforePageTransition",a)}r&&c.register(e,{instance:function(e){return new n(e||{})}})});
+csa.plugin(function(t){var e="takeRecords",i="disconnect",n="function",a=t("Metrics",{producerId:"csa"}),o=t("PageTiming"),c=t.global,r=c.PerformanceObserver,u=0,f=!1,m=0,s=c.performance,l=c.document,d=null;if(r&&s&&s.timing&&l){r=new r(function(t){d&&clearTimeout(d);t.getEntries().forEach(function(t){t.hadRecentInput||(u+=t.value,m<t.startTime&&(m=t.startTime))}),d=setTimeout(g,5e3)}),function(){try{r.observe({type:"layout-shift",buffered:!0}),d=setTimeout(g,5e3)}catch(t){}}();var v=t.exec(g);l.addEventListener("visibilitychange",function(){"hidden"===l.visibilityState&&v()}),t.once("$unload",v)}function g(){f||(f=!0,clearTimeout(d),typeof r[e]===n&&r[e](),typeof r[i]===n&&r[i](),a("recordMetric","documentCumulativeLayoutShift",u),o("mark","cumulativeLayoutShiftLastTimestamp",Math.floor(m+s.timing.navigationStart)))}});
+
+
+
+csa.plugin(function(e){var n=e.global,r=n.PerformanceObserver,t=e("Metrics",{producerId:"csa"}),o=0,c=0,i=-1,a=n.Math,l=a.max,f=a.ceil;function u(){t("recordMetric","totalBlockingTime",f(c||0)),t("recordMetric","totalBlockingTimeInclLCP",f(o||0)),t("recordMetric","maxBlockingTime",f(i||0)),c=o=0,i=-1}r&&(new r(e.exec(function(e){e.getEntries().forEach(function(e){var n=e.duration;o+=n,c+=n,i=l(n,i)})})).observe({type:"longtask",buffered:!0}),new r(e.exec(function(e){0<e.getEntries().length&&(c=0,i=-1)})).observe({type:"largest-contentful-paint",buffered:!0}),e.on("$unload",u),e.on("$beforePageTransition",u))});
+
+csa.plugin(function(i){var e="CacheDetection",n="csa-cache",s="onsuccess",u="target",d="result",p="exp",f=i.exec,t=i.config,g=t[e+".RequestID"],l=t[e+".Callback"],v=1,c=i.global,r=c.document||{},a=c.indexedDB,h=c.IDBKeyRange,I=i("Events"),x=i("Events",{producerId:"csa"});if(a&&h)try{var o=a.open(n);o.onupgradeneeded=f(function(e){e[u][d].createObjectStore(n).createIndex(p,p)}),o[s]=f(function(e){var o=e[u][d].transaction(n,"readwrite").objectStore(n);o.get(g)[s]=f(function(e){var n=D("session-id"),t=function(e){var n=D("cdn-rid");if(n)return{r:n,s:"cdn"};if(e)return{r:i.UUID().toUpperCase().replace(/-/g,"").slice(0,20),s:"device"}}(e[u][d])||{},c=t.r,r=t.s,a=!!c;!function(e){var n=Date.now(),t=h.upperBound(n);e.index(p).openCursor(t)[s]=f(function(e){var n=e[u][d];n&&(n.delete(),n.continue())}),e.put({exp:n+60*v*60*1e3},g)}(o),function(e,n,t){if(n){I("setEntity",{page:{pageSource:"cache",requestId:e,cacheRequestId:g},session:{id:t}}),x("log",{schemaId:"<ns>.CacheImpression.1"},{ent:"all"})}}(c,a,n),a&&l&&l(c,n,r)})})}catch(e){}function D(e){try{var n=r.cookie.match(RegExp("(^| )"+e+"=([^;]+)"));return n&&n[2].trim()}catch(e){}}});
+csa.plugin(function(c){var i,t="Content",e="MutationObserver",n="requestAnimationFrame",r="addedNodes",u="querySelectorAll",a="matches",o="getAttributeNames",s="getAttribute",f="dataset",l="producerId",d={ent:{element:1,page:["pageType","subPageType","requestId"]}},m=5,h=10,g="csaC",p=g+"Id",v={},y=c.config,E=y[t+".Selectors"]||[],b=y[t+".WhitelistedAttributes"]||{href:1,class:1},I=y[t+".EnableContentEntities"],w=c.global,A=w.document||{},C=A.documentElement,k=w.HTMLElement,L={},N=[],O=function(t,e,n,i){var r=this,o=c("Events",{producerId:t});r.id=e.id,r.l=o,r.e=e,r.el=n,r.rt=i,r.dlo=d,r.log=function(t,e){o("log",t,e||d)},e.id&&o("setEntity",{element:e})},U=O.prototype;function q(t){var e=(t=t||{}).element,n=t.target;return e?function(t,e){var n;n=t instanceof k?_(t)||S(e[l],t,F,c.time()):L[t.id]||$(e[l],0,t,c.time());return n}(e,t):n?function(t){var e,n=function(t){var e=null,n=0;for(;t&&n<h;){if(n++,T(t,p)){e=t;break}t=t.parentElement}return e}(t);e=n?_(n):new O("csa",{id:null},null,c.time());return e}(n):c.error("No element or target argument provided.")}function T(t,e){if(t&&t.dataset)return t.dataset[e]}function j(t,e,n){N.push({n:n,e:t,t:e}),D()}function x(){for(var t=c.time(),e=0;0<N.length;){var n=N.shift();if(v[n.n](n.e,n.t),++e%10==0&&c.time()-t>m)break}i=0,N.length&&D()}function D(){i=i||w[n](x)}function M(t,e,n){return{n:t,e:e,t:n}}function S(t,e,n,i){var r=c.UUID(),o={id:r};return e[f][p]=r,n(o,e),$(t,e,o,i)}function $(t,e,n,i){I&&(n.schemaId="<ns>.ContentEntity.2"),n.id=n.id||c.UUID();var r=new O(t,n,e,i);return I&&r.log({schemaId:"<ns>.ContentRender.1",timestamp:i}),c.emit("$content.register",r),L[n.id]=r}function _(t){return L[(t[f]||{})[p]]}function F(t,e){o in e&&(function(n,i){Object.keys(n[f]).forEach(function(t){if(!t.indexOf(g)&&g.length<t.length){var e=function(t){return(t[0]||"").toLowerCase()+t.slice(1)}(t.slice(g.length));i[e]=n[f][t]}})}(e,t),function(e,n){(e[o]()||[]).forEach(function(t){t in b&&(n[t]=e[s](t))})}(e,t))}C&&w[n]&&A[u]&&w[e]&&(E.push({selector:"*[data-csa-c-type]",entity:F}),E.push({selector:".celwidget",entity:function(t,e){F(t,e),t.slotId=t.slotId||e[s]("cel_widget_id")||e.id,t.type=t.type||"widget"}}),v[1]=function(t,e){t.forEach(function(t){t[r]&&t[r].constructor&&"NodeList"===t[r].constructor.name&&Array.prototype.forEach.call(t[r],function(t){N.unshift(M(2,t,e))})})},v[2]=function(o,c){u in o&&a in o&&E.forEach(function(t){var e=t.selector,n=o[a](e),i=o[u](e);n&&N.unshift(M(3,{e:o,s:t},c));for(var r=0;r<i.length;r++)N.unshift(M(3,{e:i[r],s:t},c))})},v[3]=function(t,e){var n=t.e;_(n)||S("csa",n,t.s.entity,e)},v[4]=function(){c.register(t,{instance:q})},new w[e](function(t){j(t,c.time(),1)}).observe(C,{childList:!0,subtree:!0}),j(C,c.time(),2),j(null,c.time(),4),c.on("$content.export",function(e){Object.keys(e).forEach(function(t){U[t]=e[t]})}))});
+csa.plugin(function(n){var i,t="IntersectionObserver",r="getAttribute",o="dataset",s="intersectionRatio",m="csaCId",a=n.config["Content.ImpressionMinimumTime"]||1e3,c=n.global,e=((c.performance||{}).timing||{}).navigationStart||n.time(),l={};function u(t){t&&(t.v=1,function(t){t.vt=n.time(),t.el.log({schemaId:"<ns>.ContentView.2",timeToViewed:t.vt-t.el.rt,pageFirstPaintToElementViewed:t.vt-e})}(t))}function f(t){t&&!t.it&&(t.i=n.time()-t.is>a,function(t){t.it=n.time(),t.el.log({schemaId:"<ns>.ContentImpressed.2",timeToImpressed:t.it-t.el.rt,pageFirstPaintToElementImpressed:t.it-e})}(t))}c[t]&&(i=new c[t](function(t){t.forEach(function(t){var e=function(t){if(t&&t[r])return l[t[o][m]]}(t.target);if(e){var i=t.intersectionRect;t.isIntersecting&&0<i.width&&0<i.height&&(e.v||u(e),.5<=t[s]&&!e.is&&(e.is=n.time(),e.timer=c.setTimeout(f.bind(this,e),a))),t[s]<.5&&!e.it&&e.timer&&(c.clearTimeout(e.timer),e.is=0,e.timer=0)}})},{threshold:[0,.5]}),n.on("$content.register",function(t){var e=t.el;e&&(l[t.id]={el:t,v:0,i:0,is:0,vt:0,it:0},i.observe(e))}))});
+csa.plugin(function(e){e.emit("$content.export",{mark:function(t,n){var o=this;o.t||(o.t=e("Timers",{logger:o.l,schemaId:"<ns>.ContentLatency.1",logOptions:o.dlo})),o.t("mark",t,n)}})});
+
+
+
+
+
+</script><script type="text/javascript">
+(function(m,a){function c(k){function f(b){b&&"string"===typeof b&&(b=(b=b.match(/^(?:https?:)?\/\/(.*?)(\/|$)/i))&&1<b.length?b[1]:null,b&&b&&("number"===typeof e[b]?e[b]++:e[b]=1))}function d(b){var e=10,d=+new Date;b&&b.timeRemaining?e=b.timeRemaining():b={timeRemaining:function(){return Math.max(0,e-(+new Date-d))}};for(var c=a.performance.getEntries(),k=e;g<c.length&&k>n;)c[g].name&&f(c[g].name),g++,k=b.timeRemaining();g>=c.length?h(!0):l()}function h(b){if(!b){b=m.scripts;var c;if(b)for(var d=
+0;d<b.length;d++)(c=b[d].getAttribute("src"))&&"undefined"!==c&&f(c)}0<Object.keys(e).length&&(p&&ue_csm.ue&&ue_csm.ue.event&&ue_csm.ue.event({domains:e,pageType:a.ue_pty||null,subPageType:a.ue_spty||null,pageTypeId:a.ue_pti||null},"csm","csm.CrossOriginDomains.2"),a.ue_ext=e)}function l(){!0===k?d():a.requestIdleCallback?a.requestIdleCallback(d):a.requestAnimationFrame?a.requestAnimationFrame(d):a.setTimeout(d,100)}function c(){if(a.performance&&a.performance.getEntries){var b=a.performance.getEntries();
+!b||0>=b.length?h(!1):l()}else h(!1)}var e=a.ue_ext||{};a.ue_ext||c();return e}function q(){setTimeout(c,r)}var s=a.ue_dserr||!1,p=!0,n=1,r=2E3,g=0;a.ue_err&&s&&(a.ue_err.errorHandlers||(a.ue_err.errorHandlers=[]),a.ue_err.errorHandlers.push({name:"ext",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel){var f=c(!0),d=[],h;for(h in f){var f=h,g=f.match(/amazon(\.com?)?\.\w{2,3}$/i);g&&1<g.length||-1!==f.indexOf("amazon-adsystem.com")||-1!==f.indexOf("amazonpay.com")||-1!==f.indexOf("cloudfront-labs.amazonaws.com")||
+d.push(h)}a.ext=d}}}));a.ue&&a.ue.isl?c():a.ue&&ue.attach&&ue.attach("load",q)})(document,window);
+
+</script>
+<script type="text/javascript">
+(function(b){var n="undefined"===typeof window.ue_bfd?1E3:window.ue_bfd;b.P&&b.P.when&&"function"===typeof window.setTimeout&&b.P.when("mshop-interactions").execute(function(d){function k(a){if(typeof a===e&&a.dataSource===p&&!(a.navType!==g&&a.navType!==l||typeof a.clickTime!==h||typeof a.events!==e||typeof a.events.pageVisible!==h&&typeof a.events.backAnimation!==h||typeof b.ue!==e||typeof b.ue.markers!==e||typeof b.uex!==m)){a.events.pageVisible=a.events.pageVisible||a.events.backAnimation;for(var c in b.ue.markers)b.ue.markers.hasOwnProperty(c)&&
+!q.hasOwnProperty(c)&&uet(c,void 0,void 0,a.events.pageVisible+1);uet("tc",void 0,void 0,a.events.pageVisible);uet("mts",void 0,void 0,a.clickTime);uet(r,void 0,void 0,a.events.pageVisible+s);(c=document.ue_backdetect)&&c.ue_back&&(b.ue.bfini=+c.ue_back.value+1);b.ue.isBFonMshop=!0;b.ue.t0=a.events.pageVisible;b.ue.viz=[t];b.ue.tag("cacheSourceMemory");b.ue.tag("mshop-interaction-"+a.navType.toLowerCase());c=ue_csm.csa&&ue_csm.csa("SPA");var d=ue_csm.csa&&ue_csm.csa("PageTiming");if(c&&d){var f={};
+a.navType===g&&(f.transitionType=u);a.navType===l&&(f.transitionType=v);f.mshopInteractionType=a.navType.toLowerCase();c("newPage",f,{keepPageAttributes:!0});d("mark","transitionStart",a.clickTime);d("mark","nativeTransitionStart",a.clickTime)}b.uex("ld",void 0,void 0,b.ue.t.ld);delete b.ue.isBFonMshop}}function w(a){a&&a.navType===g?setTimeout(function(){k(a)},n):k(a)}var p="MEMORY",g="BACK",l="FORWARD",e="object",h="number",m="function",r="ty",s=2,t="visible",q={rc:"rc",hob:"hob",hoe:"hoe",ntd:"ntd"},
+u="back-memory-cache",v="tab-switch";typeof d===e&&typeof d.addListener===m&&d.addListener(w)})})(ue_csm);
+
+</script>
+
+
+
+
+</body></html>

--- a/testdata/source/amazon/test_basic/import_results.beancount
+++ b/testdata/source/amazon/test_basic/import_results.beancount
@@ -447,3 +447,46 @@
   Expenses:FIXME              0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-02-18
+;; info: {"filename": "<testdata>/113-0374995-0086668.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "0.40 USD",
+;               "date": "2020-02-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+;                 ]
+;               },
+;               "source_account": ""
+;             },
+;             {
+;               "amount": "-6.62 USD",
+;               "date": "2020-02-18",
+;               "key_value_pairs": {
+;                 "amazon_credit_card_description": [
+;                   "Visa ending in 1234"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-02-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "113-0374995-0086668"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"113-0374995-0086668\"], \"path\": \"<testdata>/113-0374995-0086668.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A   7.32 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services LLC"
+    shipped_date: 2020-02-28
+  Expenses:FIXME:A  -1.10 USD
+    amazon_invoice_description: "Subscribe & Save"
+  Expenses:FIXME:A   0.40 USD
+    amazon_invoice_description: "Sales Tax"
+  Expenses:FIXME    -6.62 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-02-28

--- a/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
+++ b/testdata/source/amazon/test_cleared_and_invalid/import_results.beancount
@@ -148,3 +148,36 @@
   Liabilities:Credit-Card     0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-02-18
+;; info: {"filename": "<testdata>/113-0374995-0086668.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "0.40 USD",
+;               "date": "2020-02-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-02-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "113-0374995-0086668"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"113-0374995-0086668\"], \"path\": \"<testdata>/113-0374995-0086668.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A          7.32 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services LLC"
+    shipped_date: 2020-02-28
+  Expenses:FIXME:A         -1.10 USD
+    amazon_invoice_description: "Subscribe & Save"
+  Expenses:FIXME:A          0.40 USD
+    amazon_invoice_description: "Sales Tax"
+  Liabilities:Credit-Card  -6.62 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-02-28

--- a/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
+++ b/testdata/source/amazon/test_credit_card_transactions/import_results.beancount
@@ -337,3 +337,36 @@
   Liabilities:Credit-Card     0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-02-18
+;; info: {"filename": "<testdata>/113-0374995-0086668.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "0.40 USD",
+;               "date": "2020-02-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-02-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "113-0374995-0086668"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"113-0374995-0086668\"], \"path\": \"<testdata>/113-0374995-0086668.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A          7.32 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services LLC"
+    shipped_date: 2020-02-28
+  Expenses:FIXME:A         -1.10 USD
+    amazon_invoice_description: "Subscribe & Save"
+  Expenses:FIXME:A          0.40 USD
+    amazon_invoice_description: "Sales Tax"
+  Liabilities:Credit-Card  -6.62 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-02-28

--- a/testdata/source/amazon/test_prediction/import_results.beancount
+++ b/testdata/source/amazon/test_prediction/import_results.beancount
@@ -178,3 +178,36 @@
   Liabilities:Credit-Card    0.00 USD
     amazon_credit_card_description: "Amazon.com Visa Signature ending in 1234"
     transaction_date: 2019-09-18
+
+;; date: 2020-02-18
+;; info: {"filename": "<testdata>/113-0374995-0086668.html", "type": "text/html"}
+
+; features: [
+;             {
+;               "amount": "0.40 USD",
+;               "date": "2020-02-18",
+;               "key_value_pairs": {
+;                 "amazon_item_description": [
+;                   "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2020-02-18 * "Amazon.com" "Order"
+  amazon_account: "name@domain.com"
+  amazon_order_id: "113-0374995-0086668"
+  associated_data0: "{\"description\": \"Amazon order invoice\", \"meta\": [\"amazon_order_id\", \"113-0374995-0086668\"], \"path\": \"<testdata>/113-0374995-0086668.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A          7.32 USD
+    amazon_item_condition: "New"
+    amazon_item_description: "Tom's of Maine Fluoride-Free Children's Toothpaste, Kids Toothpaste, Natural Toothpaste, Silly Strawberry, 4.2 Ounce, Pack of 3"
+    amazon_item_quantity: 1
+    amazon_seller: "Amazon.com Services LLC"
+    shipped_date: 2020-02-28
+  Expenses:FIXME:A         -1.10 USD
+    amazon_invoice_description: "Subscribe & Save"
+  Expenses:FIXME:A          0.40 USD
+    amazon_invoice_description: "Sales Tax"
+  Liabilities:Credit-Card  -6.62 USD
+    amazon_credit_card_description: "Visa ending in 1234"
+    transaction_date: 2020-02-28


### PR DESCRIPTION
Judging by included testdata invoices, it seems that Amazon invoices
used to include pretax adjustments (e.g. S&H, Subscribe & Save savings,
etc) both in each individual shipment summary and in the final payments
block. But modern Amazon invoices only include these once in the
payments block, not in the shipments info.

Before this diff, the modern-style invoices would result in a
transaction with an error about grand total amount mismatch, because the
pretax adjustments in the payments block were not included in the
calculation of the expected grand total.

This commit fixes that without breaking parsing of the older style of
invoices (all existing tests pass without changes). The logic is that we
track the total amount of payment-block pretax adjustments. If we find
adjustments within shipments, that indicates an older style invoice, and
we assert that those total the same amount as the pretax adjustments in
the payments block, then we subtract the total pretax adjustments for
shipments from the tracked total from payments. For a well-formed
old-style invoice, this should leave us with zero in
`payments_pretax_adjustment_total`, so there ends up being no change in
the expected grand total.