### PR TITLE
[matching] allow grouping postings of differing sign

### DIFF
--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -467,10 +467,10 @@ def combine_transactions_using_match_set(
         txns: Tuple[Transaction, Transaction], is_cleared: IsClearedFunction,
         match_set: PostingMatchSet) -> Transaction:
     """Combines two transactions.
-    
+
     Metadata is merged (it is assumed that the metadata keys, other than
     ignorable ones, are disjoint).
-    
+
     If a cleared transaction is matched with multiple transactions (guaranteed
     to be uncleared), the result is a single merged transaction.
 
@@ -720,8 +720,7 @@ def get_aggregate_posting_candidates(
             continue
         if is_cleared(posting):
             continue
-        possible_sets.setdefault((posting.account, posting.units.currency,
-                                  posting.units.number > ZERO),
+        possible_sets.setdefault((posting.account, posting.units.currency),
                                  []).append(posting)
     results = []
     max_subset_size = 4
@@ -737,7 +736,7 @@ def get_aggregate_posting_candidates(
             meta=None)
         results.append((aggregate_posting, tuple(subset)))
 
-    for (account, currency, _), posting_list in possible_sets.items():
+    for (account, currency), posting_list in possible_sets.items():
         if len(posting_list) == 1:
             continue
         if len(posting_list) > max_subset_size:

--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -762,9 +762,10 @@ def get_aggregate_posting_candidates(
     for (account, currency), posting_list in possible_sets.items():
         if len(posting_list) == 1:
             continue
-        for samesign_list in partition(lambda p: p.units.number > ZERO, posting_list):
-            if len(samesign_list) > max_subset_size:
-                add_subset(account, currency, samesign_list, check_zero=False)
+        if len(posting_list) > max_subset_size:
+            for samesign_list in partition(lambda p: p.units.number > ZERO, posting_list):
+                if len(samesign_list) > max_subset_size:
+                    add_subset(account, currency, samesign_list, check_zero=False)
         for subset_size in range(
                 2, min(len(posting_list) + 1, max_subset_size + 1)):
             for subset in itertools.combinations(posting_list, subset_size):

--- a/beancount_import/matching_test.py
+++ b/beancount_import/matching_test.py
@@ -786,11 +786,11 @@ def test_match_grouped_differing_signs_sum_zero():
           Expenses:FIXME 1.35 USD
             note1: "B"
           Expenses:FIXME 2.90 USD
-            note1: "D"
+            note1: "C"
           Expenses:FIXME -1.35 USD
-            note1: "F"
+            note1: "D"
           Expenses:FIXME -2.90 USD
-            note1: "G"
+            note1: "E"
         """,
         journal="""
         2020-12-05 * "Narration"
@@ -807,14 +807,68 @@ def test_match_grouped_differing_signs_sum_zero():
           note3: "A"
           Assets:Bank -1.35 USD
             cleared: TRUE
-            note1: "F"
+            note1: "D"
             note2: "A"
           Expenses:Foo 1.35 USD
             note1: "B"
             note3: "B"
           Expenses:FIXME 2.90 USD
-            note1: "D"
+            note1: "C"
           Expenses:FIXME -2.90 USD
+            note1: "E"
+        """,
+    )
+
+def test_match_grouped_maximal_differing_signs():
+    # Maximal matching groups are still per-sign.
+    assert_match(
+        pending_candidate="""
+        2020-12-05 * "Narration"
+          note1: "A"
+          Expenses:FIXME 1 USD
+            note1: "B"
+          Expenses:FIXME 2 USD
+            note1: "C"
+          Expenses:FIXME 3 USD
+            note1: "D"
+          Expenses:FIXME 4 USD
+            note1: "E"
+          Expenses:FIXME 5 USD
+            note1: "F"
+          Expenses:FIXME -15 USD
             note1: "G"
+        """,
+        journal="""
+        2020-12-05 * "Narration"
+          note2: "A"
+          Assets:Bank -15 USD
+            cleared: TRUE
+            note2: "B"
+          Expenses:Foo 15 USD
+            note2: "C"
+        """,
+        matches="""
+        2020-12-05 * "Narration"
+          note1: "A"
+          note2: "A"
+          Assets:Bank -15 USD
+            cleared: TRUE
+            note1: "G"
+            note2: "B"
+          Expenses:Foo 1 USD
+            note1: "B"
+            note2: "C"
+          Expenses:Foo 2 USD
+            note1: "C"
+            note2: "C"
+          Expenses:Foo 3 USD
+            note1: "D"
+            note2: "C"
+          Expenses:Foo 4 USD
+            note1: "E"
+            note2: "C"
+          Expenses:Foo 5 USD
+            note1: "F"
+            note2: "C"
         """,
     )

--- a/beancount_import/matching_test.py
+++ b/beancount_import/matching_test.py
@@ -737,3 +737,84 @@ def test_nonmatch_fuzzy_amount():
           note: "B"
         Expenses:FIXME -99.98 USD
       """)
+
+def test_match_grouped_differing_signs():
+    # Can group postings of differing signs to make a match.
+    assert_match(
+        pending_candidate="""
+        2020-12-05 * "Narration"
+          note1: "A"
+          Expenses:FIXME:A 1.23 USD
+            note1: "B"
+          Expenses:FIXME:A -0.12 USD
+            note1: "C"
+          Assets:Bank -1.11 USD
+            note2: "A"
+        """,
+        journal="""
+        2020-12-05 * "Narration"
+          note3: "E"
+          Assets:Bank -1.11 USD
+            cleared: TRUE
+            note3: "A"
+          Expenses:Foo 1.11 USD
+            note4: "A"
+        """,
+        matches="""
+        2020-12-05 * "Narration"
+          note1: "A"
+          note3: "E"
+          Assets:Bank -1.11 USD
+            cleared: TRUE
+            note2: "A"
+            note3: "A"
+          Expenses:Foo 1.23 USD
+            note1: "B"
+            note4: "A"
+          Expenses:Foo -0.12 USD
+            note1: "C"
+            note4: "A"
+        """,
+    )
+
+def test_match_grouped_differing_signs_sum_zero():
+    # Cannot make a matching group that contains canceling transactions.
+    assert_match(
+        pending_candidate="""
+        2020-12-05 * "Narration"
+          note1: "A"
+          Expenses:FIXME 1.35 USD
+            note1: "B"
+          Expenses:FIXME 2.90 USD
+            note1: "D"
+          Expenses:FIXME -1.35 USD
+            note1: "F"
+          Expenses:FIXME -2.90 USD
+            note1: "G"
+        """,
+        journal="""
+        2020-12-05 * "Narration"
+          note3: "A"
+          Assets:Bank -1.35 USD
+            cleared: TRUE
+            note2: "A"
+          Expenses:Foo 1.35 USD
+            note3: "B"
+        """,
+        matches="""
+        2020-12-05 * "Narration"
+          note1: "A"
+          note3: "A"
+          Assets:Bank -1.35 USD
+            cleared: TRUE
+            note1: "F"
+            note2: "A"
+          Expenses:Foo 1.35 USD
+            note1: "B"
+            note3: "B"
+          Expenses:FIXME 2.90 USD
+            note1: "D"
+          Expenses:FIXME -2.90 USD
+            note1: "G"
+        """,
+    )


### PR DESCRIPTION
My use case for allowing this is importing transactions from Amazon,
which can include e.g. Subscribe & Save or other discounts along with
the cost of the item and tax, all in the same Expenses:FIXME:A account,
balancing a credit card posting for the net cost. In order for this to
match the corresponding transaction from my credit card account, we must
allow grouping the item cost, tax, and discounts into a single
MatchablePosting whose weight is the net cost, which can match the
unknown-expense leg of the credit card transaction. Currently such a
grouped MatchablePosting is disallowed by the "same sign" rule.

I verified that this change works correctly for matching transactions of
the above form. It doesn't break any of the existing matching tests.

I'm curious if there are use cases in which the "same sign" rule is
critical to avoid wrong matches? It seems like the net effect of a set
of postings all to the same account is something that should in general
be considered for matching, even if the postings are not all of the same
sign.

Feedback / counter-examples welcome!