### PR TITLE
Add support for EBAY_SALE and INVOICE_PAID in PayPal importer

### DIFF
--- a/beancount_import/source/paypal.py
+++ b/beancount_import/source/paypal.py
@@ -439,11 +439,12 @@ class PaypalSource(LinkBasedSource, Source):
             negate_funding_source_amounts = is_credit
         elif transaction_type_enum == 'REFUND':
             negate_funding_source_amounts = False
+        elif transaction_type_enum == 'EBAY_SALE':
+            negate_funding_source_amounts = False
         else:
             raise RuntimeError('Unknown transaction type: %s' % transaction_type_enum)
 
         negate_counterparty_amounts = not negate_funding_source_amounts
-
 
         if negate_funding_source_amounts:
             funding_source_amount = -funding_source_amount
@@ -476,7 +477,7 @@ class PaypalSource(LinkBasedSource, Source):
 
 
         if fee_amount.number != ZERO:
-            if negate_counterparty_amounts:
+            if negate_counterparty_amounts and transaction_type_enum != 'EBAY_SALE':
                 amount = -fee_amount
             else:
                 amount = fee_amount
@@ -538,7 +539,7 @@ class PaypalSource(LinkBasedSource, Source):
         funding_source_inventory = SimpleInventory()
         funding_source_inventory += funding_source_amount
         funding_source_account = FIXME_ACCOUNT
-        if transaction_type_enum == 'SEND_MONEY_RECEIVED':
+        if transaction_type_enum in ('SEND_MONEY_RECEIVED', 'EBAY_SALE'):
             funding_source_account = self.assets_account
             assert 'fundingSource' not in data
             funding_source_metadata = assets_account_metadata

--- a/beancount_import/source/paypal.py
+++ b/beancount_import/source/paypal.py
@@ -441,6 +441,8 @@ class PaypalSource(LinkBasedSource, Source):
             negate_funding_source_amounts = False
         elif transaction_type_enum == 'EBAY_SALE':
             negate_funding_source_amounts = False
+        elif transaction_type_enum == 'INVOICE_PAID':
+            pass
         else:
             raise RuntimeError('Unknown transaction type: %s' % transaction_type_enum)
 

--- a/testdata/source/paypal/5Y903271C7730840Z.json
+++ b/testdata/source/paypal/5Y903271C7730840Z.json
@@ -1,0 +1,118 @@
+{
+  "itemDetails": {
+    "itemList": [
+      {
+        "name": "Dungeons & Dragons 3.5 Core Books: DM Guide, Players Handbook, Monster Manual",
+        "number": "233315823254",
+        "url": "http://cgi.ebay.com/ws/eBayISAPI.dll?ViewItem&item=999",
+        "price": "$64.00",
+        "isNegative": false,
+        "itemTotalPrice": "$64.00"
+      }
+    ],
+    "shippingAmount": "$11.95"
+  },
+  "shippingDetails": [
+    {
+      "gspData": {
+        "domestic": {}
+      },
+      "address": {
+        "countryCode": "US",
+        "line1": "123 Main Street",
+        "city": "SOMEWHERE",
+        "state": "IL",
+        "postalCode": "12345",
+        "countryName": "United States",
+        "addresseeName": "John Doe"
+      },
+      "status": "Shipped",
+      "carrier": "USPS",
+      "trackingNumber": "999",
+      "shippingDate": "August 26, 2019"
+    }
+  ],
+  "fptiTag": "paymentrec",
+  "internal_id": "999",
+  "counterparty": {
+    "detailsCounterpartyText": "John Doe (john_doe)",
+    "name": "eBay - John Doe (john_doe)",
+    "url": "",
+    "isBusiness": false
+  },
+  "actions": {
+    "printPackingSlip": {
+      "content": "Print packing slip",
+      "url": "/shiplabel/packingslip/999"
+    },
+    "editTrackingInfo": {
+      "content": "Edit tracking info",
+      "url": "/addtracking/edit/5Y903271C7730840Z-999"
+    }
+  },
+  "p2pRedirect": {},
+  "links": {
+    "reportDispute": {
+      "target": "_blank",
+      "linkUrl": "/resolutioncenter/999"
+    },
+    "sellerProtectionPolicy": {
+      "target": "_blank",
+      "linkUrl": "/webapps/mpp/ua/useragreement-full#11"
+    }
+  },
+  "viewContext": "activity",
+  "displayStatus": "",
+  "transactionTypeEnum": "EBAY_SALE",
+  "transactionType": "Payment Received",
+  "txnTypeServiceKey": "PAYMENT",
+  "status": "COMPLETED",
+  "date": "August 26, 2019",
+  "creationTimeBucket": "MoreThan3Months",
+  "updateTimeBucket": "MoreThan3Months",
+  "isCredit": true,
+  "isBuyer": false,
+  "isSeller": true,
+  "buyerConfirmId": "999",
+  "transactionId": "5Y903271C7730840Z",
+  "amount": {
+    "grossAmount": "$75.95",
+    "netAmount": "$73.45",
+    "fullPageNetAmount": "$73.45",
+    "feeAmount": "$2.50",
+    "grossExceedsNet": true,
+    "isZeroFee": false,
+    "feeLabel": "Fee",
+    "rawAmounts": {
+      "gross": {
+        "value": "75.95",
+        "currencyCode": "USD"
+      }
+    }
+  },
+  "isShipped": true,
+  "sellerProtectionStatus": "NOT_ELIGIBLE",
+  "flags": {
+    "isWinSMBEligible": true,
+    "isEbay": true,
+    "isContactSuppressedForEBay": true,
+    "isCheckoutTxn": true,
+    "showPurchaseDetails": true,
+    "hasActions": true,
+    "showSellerSafety": true
+  },
+  "printDetailsLink": {
+    "linkUrl": "/myaccount/transactions/print-details/999",
+    "target": "_blank"
+  },
+  "partner": {},
+  "accountSubscriptionType": "PAYPAL_CASH_PLUS",
+  "isCFPBEligible": true,
+  "isOffersInfoEligible": false,
+  "isCCCreditFailureWithOffersRecovery": false,
+  "photoUrl": "https://pics.paypal.com/00/p/NzlkM2E4MjYtYmUwYS00M2YyLWIwNTgtNjA1MWNiM2UwYTVj/image_34.JPG",
+  "merchantLogoUrl": "https://www.paypalobjects.com/webstatic/wallet/merchants/mebay/logo_small-xhdpi.png",
+  "badge": {},
+  "hasHideEmailTreatment": false,
+  "isNewActivityUIEnabled": true
+}

--- a/testdata/source/paypal/5YB777267S0246440.json
+++ b/testdata/source/paypal/5YB777267S0246440.json
@@ -1,0 +1,113 @@
+{
+  "itemDetails": {
+    "itemList": [
+      {
+        "name": "Shipped to: JANE DOE",
+        "description": "Tracking Number:999",
+        "price": "$8.31",
+        "isNegative": false,
+        "itemTotalPrice": "$8.31"
+      },
+      {
+        "name": "Processed by:JOHN DOE",
+        "price": "$0.00",
+        "isNegative": false,
+        "itemTotalPrice": "$0.00"
+      }
+    ],
+    "itemTotalAmount": "$8.31"
+  },
+  "fundingSource": {
+    "fundingSourceList": [
+      {
+        "type": "BALANCE",
+        "amount": "$8.31",
+        "currencyCode": "USD"
+      }
+    ]
+  },
+  "shippingDetails": [
+    {
+      "address": {
+        "countryCode": "US",
+        "line1": "123 Main St",
+        "city": "Sometown",
+        "state": "TX",
+        "postalCode": "12345",
+        "countryName": "United States",
+        "addresseeName": "Jane Doe"
+      }
+    }
+  ],
+  "fptiTag": "purchase",
+  "internal_id": "999",
+  "counterparty": {
+    "detailsCounterpartyText": "Some Business",
+    "name": "Some Business",
+    "url": "http://www.example.com",
+    "isBusiness": true
+  },
+  "counterpartyBizName": "Some Business",
+  "p2pRedirect": {},
+  "links": {
+    "reportDispute": {
+      "target": "_blank",
+      "linkUrl": "/resolutioncenter/5YB777267S0246440"
+    },
+    "invoiceDetails": {
+      "target": "_blank",
+      "linkUrl": "/invoice/p/#INV2-999"
+    }
+  },
+  "paidWithHeader": "Paid with",
+  "viewContext": "activity",
+  "displayStatus": "",
+  "transactionTypeEnum": "INVOICE_PAID",
+  "transactionType": "Invoice paid",
+  "txnTypeServiceKey": "PAYMENT",
+  "status": "COMPLETED",
+  "date": "April 17, 2019",
+  "creationTimeBucket": "MoreThan3Months",
+  "updateTimeBucket": "MoreThan3Months",
+  "isCredit": false,
+  "isBuyer": true,
+  "isSeller": false,
+  "buyerConfirmId": "5YB777267S0246440",
+  "transactionId": "5YB777267S0246440",
+  "amount": {
+    "grossAmount": "$8.31",
+    "netAmount": "$8.31",
+    "fullPageNetAmount": "$8.31",
+    "feeAmount": "$0.00",
+    "grossExceedsNet": false,
+    "isZeroFee": true,
+    "feeLabel": "Fee",
+    "rawAmounts": {
+      "gross": {
+        "value": "8.31",
+        "currencyCode": "USD"
+      }
+    }
+  },
+  "isShipped": false,
+  "flags": {
+    "isWinSMBEligible": true,
+    "isInvoicePayment": true,
+    "claimStatusMessage": null,
+    "showPurchaseDetails": true,
+    "hasActions": true
+  },
+  "printDetailsLink": {
+    "linkUrl": "/myaccount/transactions/print-details/5YB777267S0246440",
+    "target": "_blank"
+  },
+  "partner": {},
+  "accountSubscriptionType": "PAYPAL_CASH_PLUS",
+  "isCFPBEligible": true,
+  "isOffersInfoEligible": false,
+  "isCCCreditFailureWithOffersRecovery": false,
+  "merchantLogoUrl": null,
+  "badge": {},
+  "hasHideEmailTreatment": false,
+  "isNewActivityUIEnabled": true
+}

--- a/testdata/source/paypal/test_basic/import_results.beancount
+++ b/testdata/source/paypal/test_basic/import_results.beancount
@@ -364,3 +364,40 @@
     paypal_funding_source_description: "Chase Visa"
     paypal_funding_source_institution: "VISA"
     paypal_funding_source_last4: "1234"
+
+;; date: 2019-08-26
+;; info: {"filename": "<testdata>/5Y903271C7730840Z.json", "type": "application/json"}
+
+; features: [
+;             {
+;               "amount": "-11.95 USD",
+;               "date": "2019-08-26",
+;               "key_value_pairs": {
+;                 "paypal_counterparty": [
+;                   "eBay - John Doe (john_doe)",
+;                   "eBay - John Doe (john_doe)"
+;                 ],
+;                 "paypal_item_name": [
+;                   "Dungeons & Dragons 3.5 Core Books: DM Guide, Players Handbook, Monster Manual"
+;                 ],
+;                 "paypal_item_number": [
+;                   "233315823254"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-08-26 * "eBay - John Doe (john_doe)" "Payment Received" ^paypal.5Y903271C7730840Z
+  associated_data0: "{\"description\": \"Paypal transaction\", \"link\": \"paypal.5Y903271C7730840Z\", \"path\": \"<testdata>/5Y903271C7730840Z.html\", \"type\": \"text/html\"}"
+  Expenses:Financial:Paypal:Fees    2.50 USD
+  Expenses:FIXME:A                -64.00 USD
+    paypal_counterparty: "eBay - John Doe (john_doe)"
+    paypal_item_name: "Dungeons & Dragons 3.5 Core Books: DM Guide, Players Handbook, Monster Manual"
+    paypal_item_number: "233315823254"
+    paypal_item_url: "http://cgi.ebay.com/ws/eBayISAPI.dll?ViewItem&item=999"
+  Expenses:FIXME:A                -11.95 USD
+    paypal_counterparty: "eBay - John Doe (john_doe)"
+    paypal_item_type: "shippingAmount"
+  Assets:Paypal                    73.45 USD
+    date: 2019-08-26
+    paypal_transaction_id: "5Y903271C7730840Z"

--- a/testdata/source/paypal/test_basic/import_results.beancount
+++ b/testdata/source/paypal/test_basic/import_results.beancount
@@ -365,6 +365,38 @@
     paypal_funding_source_institution: "VISA"
     paypal_funding_source_last4: "1234"
 
+;; date: 2019-04-17
+;; info: {"filename": "<testdata>/5YB777267S0246440.json", "type": "application/json"}
+
+; features: [
+;             {
+;               "amount": "8.31 USD",
+;               "date": "2019-04-17",
+;               "key_value_pairs": {
+;                 "paypal_counterparty": [
+;                   "Some Business"
+;                 ],
+;                 "paypal_item_description": [
+;                   "Tracking Number:999"
+;                 ],
+;                 "paypal_item_name": [
+;                   "Shipped to: JANE DOE"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-04-17 * "Some Business" "Invoice paid" ^paypal.5YB777267S0246440
+  associated_data0: "{\"description\": \"Paypal transaction\", \"link\": \"paypal.5YB777267S0246440\", \"path\": \"<testdata>/5YB777267S0246440.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A   8.31 USD
+    paypal_counterparty: "Some Business"
+    paypal_counterparty_url: "http://www.example.com"
+    paypal_item_description: "Tracking Number:999"
+    paypal_item_name: "Shipped to: JANE DOE"
+  Assets:Paypal     -8.31 USD
+    date: 2019-04-17
+    paypal_transaction_id: "5YB777267S0246440"
+
 ;; date: 2019-08-26
 ;; info: {"filename": "<testdata>/5Y903271C7730840Z.json", "type": "application/json"}
 

--- a/testdata/source/paypal/test_matching/import_results.beancount
+++ b/testdata/source/paypal/test_matching/import_results.beancount
@@ -107,6 +107,38 @@
     paypal_funding_source_institution: "VISA"
     paypal_funding_source_last4: "1234"
 
+;; date: 2019-04-17
+;; info: {"filename": "<testdata>/5YB777267S0246440.json", "type": "application/json"}
+
+; features: [
+;             {
+;               "amount": "8.31 USD",
+;               "date": "2019-04-17",
+;               "key_value_pairs": {
+;                 "paypal_counterparty": [
+;                   "Some Business"
+;                 ],
+;                 "paypal_item_description": [
+;                   "Tracking Number:999"
+;                 ],
+;                 "paypal_item_name": [
+;                   "Shipped to: JANE DOE"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-04-17 * "Some Business" "Invoice paid" ^paypal.5YB777267S0246440
+  associated_data0: "{\"description\": \"Paypal transaction\", \"link\": \"paypal.5YB777267S0246440\", \"path\": \"<testdata>/5YB777267S0246440.html\", \"type\": \"text/html\"}"
+  Expenses:FIXME:A   8.31 USD
+    paypal_counterparty: "Some Business"
+    paypal_counterparty_url: "http://www.example.com"
+    paypal_item_description: "Tracking Number:999"
+    paypal_item_name: "Shipped to: JANE DOE"
+  Assets:Paypal     -8.31 USD
+    date: 2019-04-17
+    paypal_transaction_id: "5YB777267S0246440"
+
 ;; date: 2019-08-26
 ;; info: {"filename": "<testdata>/5Y903271C7730840Z.json", "type": "application/json"}
 

--- a/testdata/source/paypal/test_matching/import_results.beancount
+++ b/testdata/source/paypal/test_matching/import_results.beancount
@@ -106,3 +106,40 @@
     paypal_funding_source_description: "Chase Visa"
     paypal_funding_source_institution: "VISA"
     paypal_funding_source_last4: "1234"
+
+;; date: 2019-08-26
+;; info: {"filename": "<testdata>/5Y903271C7730840Z.json", "type": "application/json"}
+
+; features: [
+;             {
+;               "amount": "-11.95 USD",
+;               "date": "2019-08-26",
+;               "key_value_pairs": {
+;                 "paypal_counterparty": [
+;                   "eBay - John Doe (john_doe)",
+;                   "eBay - John Doe (john_doe)"
+;                 ],
+;                 "paypal_item_name": [
+;                   "Dungeons & Dragons 3.5 Core Books: DM Guide, Players Handbook, Monster Manual"
+;                 ],
+;                 "paypal_item_number": [
+;                   "233315823254"
+;                 ]
+;               },
+;               "source_account": ""
+;             }
+;           ]
+2019-08-26 * "eBay - John Doe (john_doe)" "Payment Received" ^paypal.5Y903271C7730840Z
+  associated_data0: "{\"description\": \"Paypal transaction\", \"link\": \"paypal.5Y903271C7730840Z\", \"path\": \"<testdata>/5Y903271C7730840Z.html\", \"type\": \"text/html\"}"
+  Expenses:Financial:Paypal:Fees    2.50 USD
+  Expenses:FIXME:A                -64.00 USD
+    paypal_counterparty: "eBay - John Doe (john_doe)"
+    paypal_item_name: "Dungeons & Dragons 3.5 Core Books: DM Guide, Players Handbook, Monster Manual"
+    paypal_item_number: "233315823254"
+    paypal_item_url: "http://cgi.ebay.com/ws/eBayISAPI.dll?ViewItem&item=999"
+  Expenses:FIXME:A                -11.95 USD
+    paypal_counterparty: "eBay - John Doe (john_doe)"
+    paypal_item_type: "shippingAmount"
+  Assets:Paypal                    73.45 USD
+    date: 2019-08-26
+    paypal_transaction_id: "5Y903271C7730840Z"


### PR DESCRIPTION
Added a test transaction for each; tests and mypy pass.

INVOICE_PAID is trivial, it just works with no adjustment. EBAY_SALE requires a few adjustments but isn't too bad.