### PR TITLE
Use empty posting while balancing imported entry

### DIFF
--- a/beancount_import/source/generic_importer_source.py
+++ b/beancount_import/source/generic_importer_source.py
@@ -139,21 +139,40 @@ def get_info(raw_entry: Directive) -> dict:
         line=raw_entry.meta['lineno'],
     )
 
+def _none_units_posting_index(txn:Transaction):
+    """Index of posting with None units"""
+    for i, posting in enumerate(txn.postings):
+        if posting.units is None:
+            return i
+
 def balance_amounts(txn:Transaction)-> None:
     """Add FIXME account for the remaing amount to balance accounts"""
     inventory = SimpleInventory()
+    i = _none_units_posting_index(txn)
     for posting in txn.postings:
         inventory += posting.units
     for currency in inventory:
-        txn.postings.append(
-            Posting(
-                account=FIXME_ACCOUNT,
-                units=Amount(currency=currency, number=-inventory[currency]),
-                cost=None,
-                price=None,
-                flag=None,
-                meta={},
-            ))
+        if not inventory[currency]: # if amount already balanced
+            continue
+        if i is not None:
+            # use empty posting to balance amount instead of FIXME
+            none_posting = txn.postings[i]
+            txn.postings.append(
+                none_posting._replace(
+                    units=Amount(currency=currency, number=-inventory[currency])
+                ))
+        else:
+            txn.postings.append(
+                Posting(
+                    account=FIXME_ACCOUNT,
+                    units=Amount(currency=currency, number=-inventory[currency]),
+                    cost=None,
+                    price=None,
+                    flag=None,
+                    meta={},
+                ))
+    if i is not None:
+        txn.postings.pop(i) # remove the None posting after balancing
 
 
 def load(spec, log_status):


### PR DESCRIPTION
If an empty posting i.e., one without an amount, is entered by hand,
it should be used to balance the transaction instead of a FIXME posting.

### Example
```
2020-08-26 * "Loan to Asim"
    Assets:INR:HSBC:Saving -34000 INR
    Assets:Receivables:Asim
```
when this transaction is imported currently, it gets balanced as
```
2020-08-26 * "Loan to Asim"
    Assets:INR:HSBC:Saving -34000 INR
    Assets:Receivables:Asim 
    Assets:FIXME            34000 INR
``` 
but should be, after this PR
```
2020-08-26 * "Loan to Asim"
    Assets:INR:HSBC:Saving -34000 INR
    Assets:Receivables:Asim 34000 INR
```
