### PR TITLE
add additional check for posting.price.number

### DIFF
--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -193,7 +193,7 @@ def get_posting_weight(posting: Posting) -> Optional[Amount]:
             return Amount(posting.cost.number * posting.units.number,
                           posting.cost.currency)
         return None
-    elif posting.price is not None:
+    elif posting.price is not None and posting.price.number is not MISSING:
         return amount_mul(posting.price, posting.units.number)
     return posting.units
 


### PR DESCRIPTION
Got ` Amount's number is not a Decimal instance: <class 'beancount.core.number.MISSING'>` in `amount.py` in beancount. I don't quite want to share the whole inputfile I was using. following the same checks as line 192 for `posting.cost` seem like a good idea