### PR TITLE
Handle empty Schwab transactions CSV format.

### DIFF
--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -908,6 +908,9 @@ def _load_transactions(filename: str) -> List[RawEntry]:
             if row["Date"] == "Transactions Total":
                 found_total_line = True
                 continue
+            # If there are no transactions, Schwab includes a row with just ""
+            if row["Date"] == "":
+                continue
             assert not found_total_line
             date = _convert_date(row["Date"])
             action = SchwabAction(row["Action"])

--- a/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201130-180000.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201130-180000.CSV
@@ -1,0 +1,3 @@
+"Transactions  for account Brokerage XXXX-1234 as of 11/30/2020 18:00:00 ET From 11/16/2020 to 11/29/2020"
+"Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount",
+""


### PR DESCRIPTION
A Schwab transactions CSV with no transactions has a line following the headers that contains just `""`. Handle this line without crashing.

Added test file to exercise this case.