### PR TITLE
Schwab importer option lots and capital gains postings

### DIFF
--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -725,6 +725,7 @@ CAPITAL_GAINS_ACCOUNT_KEY = "capital_gains_account"
 TAXES_ACCOUNT_KEY = "taxes_account"
 DATE_FORMAT = "%m/%d/%Y"
 TITLE_RE = re.compile(r'"Transactions  for account (?P<account>.+) as of (?P<when>.+)"')
+OPTION_RE = re.compile(r'\w{1,4} \d\d\/\d\d\/\d\d\d\d \d*\.\d* [PC]')
 STRIP_FROM_SYMBOL_RE = re.compile(r'[^\d\w]')
 
 
@@ -941,6 +942,9 @@ def _load_transactions(filename: str) -> List[RawEntry]:
             price = _convert_decimal(row["Price"])
             fees = _convert_decimal(row["Fees & Comm"])
             amount = _convert_decimal(row["Amount"])
+            if OPTION_RE.match(row["Symbol"]) and quantity:
+                # this is an option, sold in lots of 100
+                quantity *= 100
             entries.append(
                 RawEntry(
                     account=account,
@@ -1077,6 +1081,9 @@ def _load_positions_csv(
         value_d = _convert_decimal(row["Market Value"])
         assert value_d is not None, row["Market Value"]
         value = Amount(value_d, currency="USD")
+        if OPTION_RE.match(row["Symbol"]) and quantity:
+            # this is an option, sold in lots of 100
+            quantity *= 100
         entries.append(
             RawPosition(
                 date=date,

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -108,11 +108,11 @@
     date: 2020-03-18
     schwab_action: "Sell to Close"
     source_desc: "PUT SMALL CAP INDEX $32 EXP 04/01/20"
-  Income:Capital-Gains:Schwab:SMAL040120203200P
   Assets:Schwab:Intelligent-4321:Cash               1565.32 USD
     date: 2020-03-18
     schwab_action: "Sell to Close"
     source_desc: "PUT SMALL CAP INDEX $32 EXP 04/01/20"
+  Income:Capital-Gains:Schwab:SMAL040120203200P
   Expenses:Brokerage-Fees:Schwab                       0.68 USD
 
 ;; date: 2020-03-27
@@ -124,7 +124,6 @@
     date: 2020-03-27
     schwab_action: "Sell to Open"
     source_desc: "PUT SMALL CAP INDEX $10 EXP 06/19/20"
-  Income:Capital-Gains:Schwab:SMAL061920201000P
   Assets:Schwab:Intelligent-4321:Cash               847.33 USD
     date: 2020-03-27
     schwab_action: "Sell to Open"
@@ -159,6 +158,7 @@
     date: 2020-06-12
     schwab_action: "Buy to Close"
     source_desc: "PUT SMALL CAP INDEX $10 EXP 06/19/20"
+  Income:Capital-Gains:Schwab:SMAL061920201000P
   Expenses:Brokerage-Fees:Schwab                     0.65 USD
 
 ;; date: 2020-08-24
@@ -241,11 +241,11 @@
     date: 2020-10-19
     schwab_action: "Sell"
     source_desc: "SCHWAB FUNDAMENTAL US SMALL COM ETF"
-  Income:Capital-Gains:Schwab:FNDA
   Assets:Schwab:Intelligent-4321:Cash  2533.87 USD
     date: 2020-10-19
     schwab_action: "Sell"
     source_desc: "SCHWAB FUNDAMENTAL US SMALL COM ETF"
+  Income:Capital-Gains:Schwab:FNDA
 
 ;; date: 2020-10-19
 ;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 5, "type": "text/csv"}
@@ -256,11 +256,11 @@
     date: 2020-10-19
     schwab_action: "Sell"
     source_desc: "SCHWAB US SMALL CAP ETF"
-  Income:Capital-Gains:Schwab:SCHA
   Assets:Schwab:Intelligent-4321:Cash  6013.04 USD
     date: 2020-10-19
     schwab_action: "Sell"
     source_desc: "SCHWAB US SMALL CAP ETF"
+  Income:Capital-Gains:Schwab:SCHA
 
 ;; date: 2020-11-01
 ;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 4, "type": "text/csv"}
@@ -292,11 +292,11 @@
     date: 2020-11-05
     schwab_action: "Sell"
     source_desc: "FACEBOOK INC CLASS A"
-  Income:Capital-Gains:Schwab:FB
   Assets:Schwab:Brokerage-1234:Cash  26143.94 USD
     date: 2020-11-05
     schwab_action: "Sell"
     source_desc: "FACEBOOK INC CLASS A"
+  Income:Capital-Gains:Schwab:FB
   Expenses:Brokerage-Fees:Schwab         6.06 USD
 
 ;; date: 2020-11-06

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -89,7 +89,7 @@
 
 ; features: []
 2020-03-17 * "BUYOPT - PUT SMALL CAP INDEX $32 EXP 04/01/20"
-  Assets:Schwab:Intelligent-4321:SMAL040120203200P         1 SMAL040120203200P {12.53 USD}
+  Assets:Schwab:Intelligent-4321:SMAL040120203200P       100 SMAL040120203200P {12.53 USD}
     date: 2020-03-17
     schwab_action: "Buy to Open"
     source_desc: "PUT SMALL CAP INDEX $32 EXP 04/01/20"
@@ -104,7 +104,7 @@
 
 ; features: []
 2020-03-18 * "SELLOPT - PUT SMALL CAP INDEX $32 EXP 04/01/20"
-  Assets:Schwab:Intelligent-4321:SMAL040120203200P       -1 SMAL040120203200P {} @ 15.66 USD
+  Assets:Schwab:Intelligent-4321:SMAL040120203200P     -100 SMAL040120203200P {} @ 15.66 USD
     date: 2020-03-18
     schwab_action: "Sell to Close"
     source_desc: "PUT SMALL CAP INDEX $32 EXP 04/01/20"
@@ -120,7 +120,7 @@
 
 ; features: []
 2020-03-27 * "SELLOPT - PUT SMALL CAP INDEX $10 EXP 06/19/20"
-  Assets:Schwab:Intelligent-4321:SMAL061920201000P      -1 SMAL061920201000P {} @ 8.48 USD
+  Assets:Schwab:Intelligent-4321:SMAL061920201000P    -100 SMAL061920201000P {} @ 8.48 USD
     date: 2020-03-27
     schwab_action: "Sell to Open"
     source_desc: "PUT SMALL CAP INDEX $10 EXP 06/19/20"
@@ -135,7 +135,7 @@
 
 ; features: []
 2020-03-30 * "BUYOPT - CALL SMALL CAP INDEX $83 EXP 04/03/20"
-  Assets:Schwab:Intelligent-4321:SMAL040320208300C       2 SMAL040320208300C {0.49 USD}
+  Assets:Schwab:Intelligent-4321:SMAL040320208300C     200 SMAL040320208300C {0.49 USD}
     date: 2020-03-30
     schwab_action: "Buy to Open"
     source_desc: "CALL SMALL CAP INDEX $83 EXP 04/03/20"
@@ -150,7 +150,7 @@
 
 ; features: []
 2020-06-12 * "BUYOPT - PUT SMALL CAP INDEX $10 EXP 06/19/20"
-  Assets:Schwab:Intelligent-4321:SMAL061920201000P      1 SMAL061920201000P {0.06 USD}
+  Assets:Schwab:Intelligent-4321:SMAL061920201000P    100 SMAL061920201000P {0.06 USD}
     date: 2020-06-12
     schwab_action: "Buy to Close"
     source_desc: "PUT SMALL CAP INDEX $10 EXP 06/19/20"
@@ -381,7 +381,7 @@
 ;; date: 2020-11-15
 ;; info: {"filename": "<testdata>/test_basic/positions/All-Accounts-Positions-2020-11-15.CSV", "line": 13, "type": "text/csv"}
 
-2020-11-15 balance Assets:Schwab:Intelligent-4321:SMAL040120203200P 1 SMAL040120203200P
+2020-11-15 balance Assets:Schwab:Intelligent-4321:SMAL040120203200P 100 SMAL040120203200P
 
 ;; date: 2020-11-15
 ;; info: {"filename": "<testdata>/test_basic/positions/All-Accounts-Positions-2020-11-15.CSV", "line": 14, "type": "text/csv"}


### PR DESCRIPTION
Solved two issues mentioned in #88.

Schwab reports buying 1 option for $5, but amount is $500 because options are actually sold in batches of 100. I chose to increase the quantity 100X rather than price because price may be obtained through other sources in the future.

The second issue is that selling short does not require an Income posting, while buying to cover does.

