### PR TITLE
Add Schwab bank support to schwab_csv importer

### DIFF
--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -1074,6 +1074,11 @@ class SchwabSource(DescriptionBasedSource):
             source_desc,
         )
 
+    # This source is authoritative for the Schwab accounts you download CSVs
+    # for. That allows Uncleared postings to be called out on the WebUI until
+    # they appear in the Schwab history. An example would be initiating a
+    # 2 day transfer from a bank. That transaction will debit on your bank
+    # several days before it appears on your Schwab history.
     def is_posting_cleared(self, posting: Posting):
         if posting.meta is None:
             return False
@@ -1092,7 +1097,7 @@ def _load_transactions(filename: str) -> List[Union[RawBrokerageEntry, RawBankEn
         "Amount",
         "",
     ]
-    expected_checking_field_names = [
+    expected_banking_field_names = [
         "Date",
         "Type",
         "Check #",
@@ -1111,7 +1116,7 @@ def _load_transactions(filename: str) -> List[Union[RawBrokerageEntry, RawBankEn
         reader = csv.DictReader(csvfile)
         if reader.fieldnames == expected_brokerage_field_names:
             entries = _load_brokerage_transactions(reader, account, filename)
-        elif reader.fieldnames == expected_checking_field_names:
+        elif reader.fieldnames == expected_banking_field_names:
             entries = _load_banking_transactions(reader, account, filename)
         else:
             raise RuntimeError(f"Unexpected header {reader.fieldnames}")

--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -1074,6 +1074,11 @@ class SchwabSource(DescriptionBasedSource):
             source_desc,
         )
 
+    def is_posting_cleared(self, posting: Posting):
+        if posting.meta is None:
+            return False
+        return "source_desc" in posting.meta and "schwab_action" in posting.meta
+
 
 def _load_transactions(filename: str) -> List[Union[RawBrokerageEntry, RawBankEntry]]:
     expected_brokerage_field_names = [

--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -981,6 +981,7 @@ class SchwabSource(DescriptionBasedSource):
         source_desc = cast(str, posting.meta.get(SOURCE_DESC_KEYS[0], ""))
         if not source_desc:
             return None
+        action = cast(str, posting.meta.get(POSTING_META_ACTION_KEY, ""))
         units = posting.units
         final_units = None
         if isinstance(units, Amount) or units is None:
@@ -989,7 +990,7 @@ class SchwabSource(DescriptionBasedSource):
             assert False, units
         return (
             posting.account,
-            cast(str, posting.meta[POSTING_META_ACTION_KEY]),
+            action,
             cast(datetime.date, posting.meta[POSTING_DATE_KEY]),
             final_units,
             source_desc,

--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -184,6 +184,8 @@ class RawBankEntry:
             filename=self.filename,
             line=self.line,
         )
+        if self.amount is None:
+            return None
         if self.entry_type == BankingEntryType.INTADJUST:
             return NonBrokerageBankInterest(
                interest_account=interest_account,

--- a/beancount_import/source/ultipro_google_statement.py
+++ b/beancount_import/source/ultipro_google_statement.py
@@ -297,8 +297,9 @@ def parse(text: str) -> ParseResult:
 def parse_filename(path: str):
     PDFTOTEXT_ENV='PDFTOTEXT_BINARY'
     pdftotext='pdftotext'
-    if os.getenv(PDFTOTEXT_ENV):
-        pdftotext=os.getenv(PDFTOTEXT_ENV)
+    replacement_pdftotext = os.getenv(PDFTOTEXT_ENV)
+    if replacement_pdftotext is not None:
+        pdftotext=replacement_pdftotext
     text = subprocess.check_output([pdftotext, '-raw', path, '-']).decode()
     return parse(text)
 

--- a/testdata/source/schwab_csv/test_basic/accounts.txt
+++ b/testdata/source/schwab_csv/test_basic/accounts.txt
@@ -1,6 +1,7 @@
 Assets:Schwab:Brokerage-1234
 Assets:Schwab:Brokerage-1234:Cash
 Assets:Schwab:Brokerage-1234:FB
+Assets:Schwab:Checking
 Assets:Schwab:Intelligent-4321
 Assets:Schwab:Intelligent-4321:Cash
 Assets:Schwab:Intelligent-4321:FNDA

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -62,6 +62,27 @@
     source_desc: "NOKIA CORP FSPONSORED ADR 1 ADR REPS 1 ORD SHS"
   Income:Dividend:Schwab:NOK           -6.32 USD
 
+;; date: 2019-11-22
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 13, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-1234.11 USD",
+;               "date": "2019-11-22",
+;               "key_value_pairs": {
+;                 "desc": "Check Paid #1002",
+;                 "schwab_action": "CHECK"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2019-11-22 * "CHECK - Check Paid #1002"
+  Assets:Schwab:Checking  -1234.11 USD
+    date: 2019-11-22
+    schwab_action: "CHECK"
+    source_desc: "Check Paid #1002"
+  Expenses:FIXME           1234.11 USD
+
 ;; date: 2019-12-20
 ;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 12, "type": "text/csv"}
 
@@ -83,6 +104,59 @@
     schwab_action: "Pr Yr Cash Div"
     source_desc: "VANECK VECTORS J.P. MORGAN EM LOCAL CURRENCYBOND ETF"
   Income:Dividend:Schwab:EMLC          -51.77 USD
+
+;; date: 2020-01-10
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 12, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-16.69 USD",
+;               "date": "2020-01-10",
+;               "key_value_pairs": {
+;                 "desc": "ATM AT SOME BANK",
+;                 "schwab_action": "ATM"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-01-10 * "ATM - ATM AT SOME BANK"
+  Assets:Schwab:Checking  -16.69 USD
+    date: 2020-01-10
+    schwab_action: "ATM"
+    source_desc: "ATM AT SOME BANK"
+  Expenses:FIXME           16.69 USD
+
+;; date: 2020-01-12
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 11, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-6.14 USD",
+;               "date": "2020-01-12",
+;               "key_value_pairs": {
+;                 "desc": "COMPASS VENDING   BURNABY BC #000000190",
+;                 "schwab_action": "VISA"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-01-12 * "VISA - COMPASS VENDING   BURNABY BC #000000190"
+  Assets:Schwab:Checking  -6.14 USD
+    date: 2020-01-12
+    schwab_action: "VISA"
+    source_desc: "COMPASS VENDING   BURNABY BC #000000190"
+  Expenses:FIXME           6.14 USD
+
+;; date: 2020-01-31
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 10, "type": "text/csv"}
+
+; features: []
+2020-01-31 * "INTADJUST - Interest Paid"
+  Assets:Schwab:Checking   0.09 USD
+    date: 2020-01-31
+    schwab_action: "INTADJUST"
+    source_desc: "Interest Paid"
+  Income:Interest:Schwab  -0.09 USD
 
 ;; date: 2020-03-17
 ;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 17, "type": "text/csv"}
@@ -193,23 +267,23 @@
 ;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 5, "type": "text/csv"}
 
 ; features: []
-2020-09-15 * "INVBANKTRAN - BANK INT 081620-091520 SCHWAB PREMIER BANK"
+2020-09-15 * "INTEREST - BANK INT 081620-091520 SCHWAB PREMIER BANK"
   Assets:Schwab:Brokerage-1234:Cash   0.05 USD
     date: 2020-09-15
     schwab_action: "Bank Interest"
     source_desc: "BANK INT 081620-091520 SCHWAB PREMIER BANK"
-  Income:Dividend:Schwab             -0.05 USD
+  Income:Interest:Schwab             -0.05 USD
 
 ;; date: 2020-10-15
 ;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 8, "type": "text/csv"}
 
 ; features: []
-2020-10-15 * "INVBANKTRAN - BANK INT SCHWAB BANK"
+2020-10-15 * "INTEREST - BANK INT SCHWAB BANK"
   Assets:Schwab:Intelligent-4321:Cash   33.93 USD
     date: 2020-10-15
     schwab_action: "Bank Interest"
     source_desc: "BANK INT SCHWAB BANK"
-  Income:Dividend:Schwab               -33.93 USD
+  Income:Interest:Schwab               -33.93 USD
 
 ;; date: 2020-10-19
 ;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 7, "type": "text/csv"}
@@ -225,7 +299,7 @@
 ;               "source_account": "Assets:Schwab:Intelligent-4321:Cash"
 ;             }
 ;           ]
-2020-10-19 * "INVBANKTRAN - Tfr SOME BANK"
+2020-10-19 * "TRANSFER - Tfr SOME BANK"
   Assets:Schwab:Intelligent-4321:Cash  -4000.00 USD
     date: 2020-10-19
     schwab_action: "MoneyLink Transfer"
@@ -261,6 +335,69 @@
     schwab_action: "Sell"
     source_desc: "SCHWAB US SMALL CAP ETF"
   Income:Capital-Gains:Schwab:SCHA
+
+;; date: 2020-10-26
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 9, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "2500.00 USD",
+;               "date": "2020-10-26",
+;               "key_value_pairs": {
+;                 "desc": "Electronic Deposit",
+;                 "schwab_action": "ACH"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-10-26 * "ACH - Electronic Deposit"
+  Assets:Schwab:Checking   2500.00 USD
+    date: 2020-10-26
+    schwab_action: "ACH"
+    source_desc: "Electronic Deposit"
+  Expenses:FIXME          -2500.00 USD
+
+;; date: 2020-10-27
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 8, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "1.56 USD",
+;               "date": "2020-10-27",
+;               "key_value_pairs": {
+;                 "desc": "JPMorgan Chase Auth Crdt",
+;                 "schwab_action": "ACH"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-10-27 * "ACH - JPMorgan Chase Auth Crdt"
+  Assets:Schwab:Checking   1.56 USD
+    date: 2020-10-27
+    schwab_action: "ACH"
+    source_desc: "JPMorgan Chase Auth Crdt"
+  Expenses:FIXME          -1.56 USD
+
+;; date: 2020-10-27
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 7, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-1.10 USD",
+;               "date": "2020-10-27",
+;               "key_value_pairs": {
+;                 "desc": "JPMorgan Chase Auth Debit",
+;                 "schwab_action": "ACH"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-10-27 * "ACH - JPMorgan Chase Auth Debit"
+  Assets:Schwab:Checking  -1.10 USD
+    date: 2020-10-27
+    schwab_action: "ACH"
+    source_desc: "JPMorgan Chase Auth Debit"
+  Expenses:FIXME           1.10 USD
 
 ;; date: 2020-11-01
 ;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 4, "type": "text/csv"}
@@ -335,7 +472,7 @@
 ;               "source_account": "Assets:Schwab:Brokerage-1234:Cash"
 ;             }
 ;           ]
-2020-11-10 * "INVBANKTRAN - JOURNAL TO 00004321"
+2020-11-10 * "TRANSFER - JOURNAL TO 00004321"
   Assets:Schwab:Brokerage-1234:Cash  -123.45 USD
     date: 2020-11-10
     schwab_action: "Journal"
@@ -356,12 +493,33 @@
 ;               "source_account": "Assets:Schwab:Intelligent-4321:Cash"
 ;             }
 ;           ]
-2020-11-10 * "INVBANKTRAN - JOURNAL FRM 00001234"
+2020-11-10 * "TRANSFER - JOURNAL FRM 00001234"
   Assets:Schwab:Intelligent-4321:Cash   123.45 USD
     date: 2020-11-10
     schwab_action: "Journal"
     source_desc: "JOURNAL FRM 00001234"
   Expenses:FIXME                       -123.45 USD
+
+;; date: 2020-11-13
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 6, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "10500.00 USD",
+;               "date": "2020-11-13",
+;               "key_value_pairs": {
+;                 "desc": "JPMorgan Chase Ext Trnsfr",
+;                 "schwab_action": "ACH"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-11-13 * "ACH - JPMorgan Chase Ext Trnsfr"
+  Assets:Schwab:Checking   10500.00 USD
+    date: 2020-11-13
+    schwab_action: "ACH"
+    source_desc: "JPMorgan Chase Ext Trnsfr"
+  Expenses:FIXME          -10500.00 USD
 
 ;; date: 2020-11-15
 ;; info: {"filename": "<testdata>/test_basic/positions/All-Accounts-Positions-2020-11-15.CSV", "line": 5, "type": "text/csv"}

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -151,7 +151,7 @@
 ;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 10, "type": "text/csv"}
 
 ; features: []
-2020-01-31 * "INTADJUST - Interest Paid"
+2020-01-31 * "INTEREST - Interest Paid"
   Assets:Schwab:Checking   0.09 USD
     date: 2020-01-31
     schwab_action: "INTADJUST"
@@ -520,6 +520,27 @@
     schwab_action: "ACH"
     source_desc: "JPMorgan Chase Ext Trnsfr"
   Expenses:FIXME          -10500.00 USD
+
+;; date: 2020-11-13
+;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 5, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-10500.00 USD",
+;               "date": "2020-11-13",
+;               "key_value_pairs": {
+;                 "desc": "Funds Transfer to Brokerage -9999",
+;                 "schwab_action": "TRANSFER"
+;               },
+;               "source_account": "Assets:Schwab:Checking"
+;             }
+;           ]
+2020-11-13 * "TRANSFER - Funds Transfer to Brokerage -9999"
+  Assets:Schwab:Checking  -10500.00 USD
+    date: 2020-11-13
+    schwab_action: "TRANSFER"
+    source_desc: "Funds Transfer to Brokerage -9999"
+  Expenses:FIXME           10500.00 USD
 
 ;; date: 2020-11-15
 ;; info: {"filename": "<testdata>/test_basic/positions/All-Accounts-Positions-2020-11-15.CSV", "line": 5, "type": "text/csv"}

--- a/testdata/source/schwab_csv/test_basic/journal.beancount
+++ b/testdata/source/schwab_csv/test_basic/journal.beancount
@@ -4,13 +4,18 @@
 1900-01-01 open Assets:Schwab:Brokerage-1234
     schwab_account: "Brokerage XXXX-1234"
     div_income_account: "Income:Dividend:Schwab"
+    interest_income_account: "Income:Interest:Schwab"
     capital_gains_account: "Income:Capital-Gains:Schwab"
     fees_account: "Expenses:Brokerage-Fees:Schwab"
 1900-01-01 open Assets:Schwab:Brokerage-1234:Cash
 1900-01-01 open Assets:Schwab:Brokerage-1234:FB
+1900-01-01 open Assets:Schwab:Checking
+    schwab_account: "EAC"
+    interest_income_account: "Income:Interest:Schwab"
 1900-01-01 open Assets:Schwab:Intelligent-4321
     schwab_account: "Intelligent XXXX-4321"
     div_income_account: "Income:Dividend:Schwab"
+    interest_income_account: "Income:Interest:Schwab"
     capital_gains_account: "Income:Capital-Gains:Schwab"
     fees_account: "Expenses:Brokerage-Fees:Schwab"
 1900-01-01 open Assets:Schwab:Intelligent-4321:Cash

--- a/testdata/source/schwab_csv/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV
@@ -1,0 +1,12 @@
+Transactions  for Checking account EAC as of 12/23/2020 16:00:10 ET
+"Date","Type","Check #","Description","Withdrawal (-)","Deposit (+)","RunningBalance"
+"Pending Transactions are not reflected within this sort criterion."
+"Posted Transactions""11/13/2020","TRANSFER","","Funds Transfer to Brokerage -9999","$10,500.00","","$50.01"
+"11/13/2020","ACH","","JPMorgan Chase Ext Trnsfr","","$10,500.00","$10,550.01"
+"10/27/2020","ACH","","JPMorgan Chase Auth Debit","$1.10","","$2,550.00"
+"10/27/2020","ACH","","JPMorgan Chase Auth Crdt","","$1.56","$2,550.55"
+"10/26/2020","ACH","","Electronic Deposit","","$2,500.00","$11,550.00"
+"01/31/2020","INTADJUST","","Interest Paid","","$0.09","$1133.94"
+"01/12/2020","VISA","","COMPASS VENDING   BURNABY BC #000000190","$6.14","","$1133.85"
+"01/10/2020","ATM","","ATM AT SOME BANK","$16.69","","$1139.99"
+"11/22/2019","CHECK","1002","Check Paid #1002","$1,234.11","","$1,111.81"

--- a/testdata/source/schwab_csv/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV
@@ -1,7 +1,8 @@
 Transactions  for Checking account EAC as of 12/23/2020 16:00:10 ET
 "Date","Type","Check #","Description","Withdrawal (-)","Deposit (+)","RunningBalance"
 "Pending Transactions are not reflected within this sort criterion."
-"Posted Transactions""11/13/2020","TRANSFER","","Funds Transfer to Brokerage -9999","$10,500.00","","$50.01"
+"Posted Transactions"
+"11/13/2020","TRANSFER","","Funds Transfer to Brokerage -9999","$10,500.00","","$50.01"
 "11/13/2020","ACH","","JPMorgan Chase Ext Trnsfr","","$10,500.00","$10,550.01"
 "10/27/2020","ACH","","JPMorgan Chase Auth Debit","$1.10","","$2,550.00"
 "10/27/2020","ACH","","JPMorgan Chase Auth Crdt","","$1.56","$2,550.55"


### PR DESCRIPTION
I have quite a lot of activity / business with Schwab including a checking account so I brought in support for everything I could find in my own Schwab CSV files. In the spirit of #88 .

Other changes in the schwab_csv source: (apologies for not splitting these out, if that's a bother I can do the extra book keeping to get them into independent pull reqs).
- Added support for 7 new BrokerageActions.
- Added support for fractional shares, which Schwab added last year. You can get these in your account via dividend re-investment or the fractional share purchase feature. The source previously assume int for share quantities.
- Make schwab_csv post cleared status for Schwab accounts. This lets uncleared transactions properly appear in the import webui.
- Make the currency configurable just in case instead of hardcoding USD.
- Added a dedicated interest type that we now use consistently for Checking account interest and "Bank interest" paid on brokerage account cash balances.
- Tweaked some of the key regexps to work on the files I am getting from Schwab in addition to the testfiles.

Known caveats:
- The banking CSVs indicate they may contain pending transactions in a special way. I didn't have any in my file to add support for. Likely the importer will import them the same whether they are pending or not. This could result in some extraneous imports for pending auth charges that would normally drop off. If someone donates a CSV with the format it would be easy to add support for it.
- Does not support corporate equity awards accounts - for Google's at least it is quite different from the Brokerage format and I had written my own importer before schwab_csv was added. If there's interest I can open source the Google equity awards source.