### PR TITLE
Fix tox regression I introduced in #90

### DIFF
--- a/beancount_import/source/ultipro_google_statement.py
+++ b/beancount_import/source/ultipro_google_statement.py
@@ -297,8 +297,9 @@ def parse(text: str) -> ParseResult:
 def parse_filename(path: str):
     PDFTOTEXT_ENV='PDFTOTEXT_BINARY'
     pdftotext='pdftotext'
-    if os.getenv(PDFTOTEXT_ENV):
-        pdftotext=os.getenv(PDFTOTEXT_ENV)
+    replacement_pdftotext = os.getenv(PDFTOTEXT_ENV)
+    if replacement_pdftotext is not None:
+        pdftotext=replacement_pdftotext
     text = subprocess.check_output([pdftotext, '-raw', path, '-']).decode()
     return parse(text)
 


### PR DESCRIPTION
I didn't realize I should be running tox checks and it turns out
the type inference engine wasn't able to correctly infer
non-nullability previously. Introducing a variable fixes the check.