### PR TITLE
ofx: support non-sale transfers out

### DIFF
--- a/beancount_import/source/ofx.py
+++ b/beancount_import/source/ofx.py
@@ -916,14 +916,14 @@ class ParsedOfxStatement(object):
                 units = normalize_fraction(raw.units)
                 if quantity_round_digits is not None:
                     units = round(units, quantity_round_digits)
-                unitprice = normalize_fraction(raw.unitprice)
+                if raw.unitprice is not None:
+                    unitprice = normalize_fraction(raw.unitprice)
 
                 cost_spec = None
                 price = None
                 is_sale = False
                 if raw.trantype in SELL_TYPES or (raw.trantype == 'TRANSFER' and
                                                   units < ZERO):
-                    is_sale = True
                     units = -abs(units)
                     # For sell transactions, rely on beancount to determine the matching lot.
                     cost_spec = CostSpec(
@@ -933,7 +933,9 @@ class ParsedOfxStatement(object):
                         date=None,
                         label=None,
                         merge=False)
-                    price = Amount(number=unitprice, currency=self.currency)
+                    if unitprice != ZERO:
+                        is_sale = True
+                        price = Amount(number=unitprice, currency=self.currency)
                 elif raw.trantype == 'TRANSFER' and units > ZERO:
                     # Transfer in.
                     # OFX does not specify the lot information, so it will have to be manually fixed.


### PR DESCRIPTION
This works with transactions like a charitable donation or a brokerage
transfer which don't involve liquidating the asset that is being transferred out.