### PR TITLE
Support "Stock Split" in Schwab CSV importer

### DIFF
--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -309,7 +309,6 @@ class RawBrokerageEntry(RawEntry):
             assert self.quantity is not None
             lot_splits = lots.split(acct, self.symbol, self.date, self.quantity)
             return StockSplit(
-                capital_gains_account=capital_gains_account,
                 lot_splits=lot_splits,
                 **shared_attrs,
             )
@@ -612,7 +611,6 @@ class Transfer(TransactionEntry):
 
 @dataclass(frozen=True)
 class StockSplit(TransactionEntry):
-    capital_gains_account: str
     lot_splits: List[LotSplit]
 
     def get_sub_account(self) -> Optional[str]:
@@ -659,20 +657,7 @@ class StockSplit(TransactionEntry):
                 )
             )
 
-        postings.append(
-            Posting(
-                account=self.get_cap_gains_account(),
-                units=MISSING,
-                cost=None,
-                price=None,
-                flag=None,
-                meta={},
-            )
-        )
         return postings
-
-    def get_cap_gains_account(self) -> str:
-        return f"{self.capital_gains_account}:{self.amount.currency}"
 
     def get_narration_prefix(self) -> str:
         return "STOCKSPLIT"

--- a/testdata/source/schwab_csv/test_basic/accounts.txt
+++ b/testdata/source/schwab_csv/test_basic/accounts.txt
@@ -6,6 +6,7 @@ Assets:Schwab:Intelligent-4321
 Assets:Schwab:Intelligent-4321:Cash
 Assets:Schwab:Intelligent-4321:FNDA
 Assets:Schwab:Intelligent-4321:GOOG
+Assets:Schwab:Intelligent-4321:HYLB
 Assets:Schwab:Intelligent-4321:SCHA
 Assets:Schwab:Intelligent-4321:SMAL040120203200P
 Assets:Schwab:Intelligent-4321:SMAL040320208300C

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -1,5 +1,5 @@
 ;; date: 2018-06-28
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 16, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 17, "type": "text/csv"}
 
 ; features: [
 ;             {
@@ -20,7 +20,7 @@
   Expenses:FIXME                        0.05 USD
 
 ;; date: 2019-06-11
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 15, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 16, "type": "text/csv"}
 
 ; features: [
 ;             {
@@ -41,7 +41,7 @@
   Expenses:FIXME                        1.05 USD
 
 ;; date: 2019-06-11
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 14, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 15, "type": "text/csv"}
 
 ; features: []
 2019-06-11 * "INVBANKTRAN - NOKIA CORP FSPONSORED ADR 1 ADR REPS 1 ORD SHS"
@@ -52,7 +52,7 @@
   Expenses:Brokerage-Fees:Schwab        0.47 USD
 
 ;; date: 2019-06-11
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 13, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 14, "type": "text/csv"}
 
 ; features: []
 2019-06-11 * "INCOME - DIV - NOKIA CORP FSPONSORED ADR 1 ADR REPS 1 ORD SHS"
@@ -84,7 +84,7 @@
   Expenses:FIXME           1234.11 USD
 
 ;; date: 2019-12-20
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 12, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 13, "type": "text/csv"}
 
 ; features: []
 2019-12-20 * "INCOME - DIV - ISHARES CORE MSCI EMERGING ETF"
@@ -95,7 +95,7 @@
   Income:Dividend:Schwab:IEMG          -156.87 USD
 
 ;; date: 2020-01-06
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 11, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 12, "type": "text/csv"}
 
 ; features: []
 2020-01-06 * "INCOME - DIV - VANECK VECTORS J.P. MORGAN EM LOCAL CURRENCYBOND ETF"
@@ -159,7 +159,7 @@
   Income:Interest:Schwab  -0.09 USD
 
 ;; date: 2020-03-17
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 17, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 18, "type": "text/csv"}
 
 ; features: []
 2020-03-17 * "BUYOPT - PUT SMALL CAP INDEX $32 EXP 04/01/20"
@@ -174,7 +174,7 @@
   Expenses:Brokerage-Fees:Schwab                        0.65 USD
 
 ;; date: 2020-03-18
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 18, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 19, "type": "text/csv"}
 
 ; features: []
 2020-03-18 * "SELLOPT - PUT SMALL CAP INDEX $32 EXP 04/01/20"
@@ -190,7 +190,7 @@
   Expenses:Brokerage-Fees:Schwab                       0.68 USD
 
 ;; date: 2020-03-27
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 19, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 20, "type": "text/csv"}
 
 ; features: []
 2020-03-27 * "SELLOPT - PUT SMALL CAP INDEX $10 EXP 06/19/20"
@@ -205,7 +205,7 @@
   Expenses:Brokerage-Fees:Schwab                      0.67 USD
 
 ;; date: 2020-03-30
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 21, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 22, "type": "text/csv"}
 
 ; features: []
 2020-03-30 * "BUYOPT - CALL SMALL CAP INDEX $83 EXP 04/03/20"
@@ -220,7 +220,7 @@
   Expenses:Brokerage-Fees:Schwab                      1.34 USD
 
 ;; date: 2020-06-12
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 20, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 21, "type": "text/csv"}
 
 ; features: []
 2020-06-12 * "BUYOPT - PUT SMALL CAP INDEX $10 EXP 06/19/20"
@@ -236,7 +236,7 @@
   Expenses:Brokerage-Fees:Schwab                     0.65 USD
 
 ;; date: 2020-08-24
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 10, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 11, "type": "text/csv"}
 
 ; features: []
 2020-08-24 * "BUYSTOCK - SCHWAB FUNDAMENTAL US SMALL COM ETF"
@@ -250,7 +250,7 @@
     source_desc: "SCHWAB FUNDAMENTAL US SMALL COM ETF"
 
 ;; date: 2020-08-24
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 9, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 10, "type": "text/csv"}
 
 ; features: []
 2020-08-24 * "BUYSTOCK - SCHWAB US SMALL CAP ETF"
@@ -275,7 +275,7 @@
   Income:Interest:Schwab             -0.05 USD
 
 ;; date: 2020-10-15
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 8, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 9, "type": "text/csv"}
 
 ; features: []
 2020-10-15 * "INTEREST - BANK INT SCHWAB BANK"
@@ -286,7 +286,7 @@
   Income:Interest:Schwab               -33.93 USD
 
 ;; date: 2020-10-19
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 7, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 8, "type": "text/csv"}
 
 ; features: [
 ;             {
@@ -307,7 +307,7 @@
   Expenses:FIXME                        4000.00 USD
 
 ;; date: 2020-10-19
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 6, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 7, "type": "text/csv"}
 
 ; features: []
 2020-10-19 * "SELLSTOCK - SCHWAB FUNDAMENTAL US SMALL COM ETF"
@@ -322,7 +322,7 @@
   Income:Capital-Gains:Schwab:FNDA
 
 ;; date: 2020-10-19
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 5, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 6, "type": "text/csv"}
 
 ; features: []
 2020-10-19 * "SELLSTOCK - SCHWAB US SMALL CAP ETF"
@@ -437,7 +437,7 @@
   Expenses:Brokerage-Fees:Schwab         6.06 USD
 
 ;; date: 2020-11-06
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 4, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 5, "type": "text/csv"}
 
 ; features: []
 2020-11-06 * "INCOME - DIV - SCHWAB US TIPS ETF"
@@ -448,7 +448,7 @@
   Income:Dividend:Schwab:SCHP          -136.69 USD
 
 ;; date: 2020-11-09
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 3, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 4, "type": "text/csv"}
 
 ; features: []
 2020-11-09 * "INCOME - DIV - XTRACKERS USD HIGH YIELDCOR BND ETF"
@@ -480,7 +480,7 @@
   Expenses:FIXME                      123.45 USD
 
 ;; date: 2020-11-10
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 2, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 3, "type": "text/csv"}
 
 ; features: [
 ;             {
@@ -541,6 +541,27 @@
     schwab_action: "TRANSFER"
     source_desc: "Funds Transfer to Brokerage -9999"
   Expenses:FIXME           10500.00 USD
+
+;; date: 2020-11-13
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 2, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "18 HYLB",
+;               "date": "2020-11-13",
+;               "key_value_pairs": {
+;                 "desc": "XTRACKERS USD HIGH YIELDCOR BND ETF",
+;                 "schwab_action": "Stock Split"
+;               },
+;               "source_account": "Assets:Schwab:Intelligent-4321:HYLB"
+;             }
+;           ]
+2020-11-13 * "STOCKSPLIT - XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB   18 HYLB
+    date: 2020-11-13
+    schwab_action: "Stock Split"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Expenses:FIXME                       -18 HYLB
 
 ;; date: 2020-11-15
 ;; info: {"filename": "<testdata>/test_basic/positions/All-Accounts-Positions-2020-11-15.CSV", "line": 5, "type": "text/csv"}
@@ -619,7 +640,7 @@
   Expenses:FIXME          -20000.00 USD
 
 ;; date: 2021-02-16
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 22, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 23, "type": "text/csv"}
 
 ; features: [
 ;             {
@@ -640,7 +661,7 @@
   Expenses:FIXME                        12.3456 GOOG
 
 ;; date: 2021-03-22
-;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 23, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 24, "type": "text/csv"}
 
 ; features: [
 ;             {

--- a/testdata/source/schwab_csv/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV
@@ -1,5 +1,6 @@
 "Transactions  for account Intelligent XXXX-4321 as of 11/15/2020 18:01:20 ET"
 "Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount",
+"11/14/2020 as of 11/13/2020","Stock Split","HYLB","XTRACKERS USD HIGH YIELDCOR BND ETF","18","$40.008","","",
 "11/10/2020","Journal","","JOURNAL FRM 00001234","","","","$123.45",
 "11/09/2020","Cash Dividend","HYLB","XTRACKERS USD HIGH YIELDCOR BND ETF","","","","$92.16",
 "11/06/2020","Cash Dividend","SCHP","SCHWAB US TIPS ETF","","","","$136.69",

--- a/testdata/source/schwab_csv/test_lots/accounts.txt
+++ b/testdata/source/schwab_csv/test_lots/accounts.txt
@@ -1,4 +1,5 @@
 Assets:Schwab:Intelligent-4321
 Assets:Schwab:Intelligent-4321:Cash
 Assets:Schwab:Intelligent-4321:FNDA
+Assets:Schwab:Intelligent-4321:HYLB
 Assets:Schwab:Intelligent-4321:SCHA

--- a/testdata/source/schwab_csv/test_lots/import_results.beancount
+++ b/testdata/source/schwab_csv/test_lots/import_results.beancount
@@ -139,7 +139,6 @@
     date: 2020-10-13
     schwab_action: "Stock Split"
     source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
-  Income:Capital-Gains:Schwab:HYLB
 
 ;; date: 2020-10-19
 ;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 3, "type": "text/csv"}

--- a/testdata/source/schwab_csv/test_lots/import_results.beancount
+++ b/testdata/source/schwab_csv/test_lots/import_results.beancount
@@ -1,5 +1,5 @@
 ;; date: 2020-08-24
-;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 6, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 9, "type": "text/csv"}
 
 ; features: []
 2020-08-24 * "BUYSTOCK - SCHWAB FUNDAMENTAL US SMALL COM ETF"
@@ -13,7 +13,7 @@
     source_desc: "SCHWAB FUNDAMENTAL US SMALL COM ETF"
 
 ;; date: 2020-08-24
-;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 5, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 8, "type": "text/csv"}
 
 ; features: []
 2020-08-24 * "BUYSTOCK - SCHWAB US SMALL CAP ETF"
@@ -51,8 +51,36 @@
 
 2020-08-25 price SCHA                                71.39 USD
 
+;; date: 2020-08-30
+;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 7, "type": "text/csv"}
+
+; features: []
+2020-08-30 * "BUYSTOCK - XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB        8 HYLB {20.00 USD}
+    date: 2020-08-30
+    schwab_action: "Buy"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:Cash  -160.00 USD
+    date: 2020-08-30
+    schwab_action: "Buy"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+
+;; date: 2020-08-31
+;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 6, "type": "text/csv"}
+
+; features: []
+2020-08-31 * "BUYSTOCK - XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB       12 HYLB {10.00 USD}
+    date: 2020-08-31
+    schwab_action: "Buy"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:Cash  -120.00 USD
+    date: 2020-08-31
+    schwab_action: "Buy"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+
 ;; date: 2020-09-24
-;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 4, "type": "text/csv"}
+;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 5, "type": "text/csv"}
 
 ; features: []
 2020-09-24 * "BUYSTOCK - SCHWAB US SMALL CAP ETF"
@@ -89,6 +117,29 @@
 ;; info: {"filename": "<testdata>/test_lots/positions/Intelligent-Positions-2020-09-25.CSV", "line": 5, "type": "text/csv"}
 
 2020-09-25 price SCHA                                72.56 USD
+
+;; date: 2020-10-13
+;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 4, "type": "text/csv"}
+
+; features: []
+2020-10-13 * "STOCKSPLIT - XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB  -12 HYLB {10.00 USD, 2020-08-31}
+    date: 2020-10-13
+    schwab_action: "Stock Split"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB   24 HYLB {5.00 USD, 2020-08-31}
+    date: 2020-10-13
+    schwab_action: "Stock Split"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB   -8 HYLB {20.00 USD, 2020-08-30}
+    date: 2020-10-13
+    schwab_action: "Stock Split"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Assets:Schwab:Intelligent-4321:HYLB   16 HYLB {10.00 USD, 2020-08-30}
+    date: 2020-10-13
+    schwab_action: "Stock Split"
+    source_desc: "XTRACKERS USD HIGH YIELDCOR BND ETF"
+  Income:Capital-Gains:Schwab:HYLB
 
 ;; date: 2020-10-19
 ;; info: {"filename": "<testdata>/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 3, "type": "text/csv"}

--- a/testdata/source/schwab_csv/test_lots/positions/lots/2020-09-25/HYLB.csv
+++ b/testdata/source/schwab_csv/test_lots/positions/lots/2020-09-25/HYLB.csv
@@ -1,0 +1,6 @@
+"HYLB Lot Details for XXXX-4321 as of 02:45 AM ET, 09/25/2020"
+
+"Open Date","Quantity","Price","Cost/Share","Market Value","Cost Basis","Gain/Loss $","Gain/Loss %","Holding Period",
+"08/31/2020 13:42:07","12","$10.00","$10.00","$120.00","$120.00","$0.00","+0.00%","Short Term",
+"08/30/2020 13:42:07","8","$10.00","$20.00","$80.00","$160.00","-$80.00","-50.00%","Short Term",
+"Total","20","--","--","$200.00","$280.00","$0.40","-28.5%","--",

--- a/testdata/source/schwab_csv/test_lots/positions/lots/2020-10-25/HYLB.csv
+++ b/testdata/source/schwab_csv/test_lots/positions/lots/2020-10-25/HYLB.csv
@@ -1,0 +1,6 @@
+"HYLB Lot Details for XXXX-4321 as of 02:45 AM ET, 10/25/2020"
+
+"Open Date","Quantity","Price","Cost/Share","Market Value","Cost Basis","Gain/Loss $","Gain/Loss %","Holding Period",
+"08/31/2020 13:42:07","24","$1.00","$5.00","$24.00","$120.00","$0.00","+0.00%","Short Term",
+"08/30/2020 13:42:07","16","$1.00","$10.00","$16.00","$160.00","$0.00","+0.00%","Short Term",
+"Total","20","--","--","$40.00","$280.00","$0.00","+0.00%","--",

--- a/testdata/source/schwab_csv/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV
+++ b/testdata/source/schwab_csv/test_lots/transactions/Intelligent_Transactions_20201115-180120.CSV
@@ -2,7 +2,10 @@
 "Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount",
 "10/19/2020","Sell","SCHA","SCHWAB US SMALL CAP ETF","19.5","$74.23","","$1447.49",
 "10/19/2020","Sell","FNDA","SCHWAB FUNDAMENTAL US SMALL CAP ETF","1","$35.00","","$35.00",
+"10/14/2020 as of 10/13/2020","Stock Split","HYLB","XTRACKERS USD HIGH YIELDCOR BND ETF","20","$5.00","","",
 "09/24/2020","Buy","SCHA","SCHWAB US SMALL CAP ETF","20","$72.56","","-$1451.20",
+"08/31/2020","Buy","HYLB","XTRACKERS USD HIGH YIELDCOR BND ETF","12","$10.00","","-$120.00",
+"08/30/2020","Buy","HYLB","XTRACKERS USD HIGH YIELDCOR BND ETF","8","$20.00","","-$160.00",
 "08/24/2020","Buy","SCHA","SCHWAB US SMALL CAP ETF","10","$71.35","","-$713.50",
 "08/24/2020","Buy","FNDA","SCHWAB FUNDAMENTAL US SMALL COM ETF","1","$34.89","","-$34.89",
-Transactions Total,"","","","","","",-$717.10
+Transactions Total,"","","","","","",-$897.10


### PR DESCRIPTION
This adds support for the "Stock Split" action in a Schwab CSV transaction file.

If the optional lot-details feature is not in use, the generated transaction will likely need manual updating; this is pretty much unavoidable since there isn't enough information in the transactions CSV to generate a transaction that updates all existing lots with the stock split.

If the optional lot-details feature is in use, then the importer will generate a correct transaction that, for each lot, subtracts all current shares at the old price and adds all new shares at the new price, with lot date preserved. The only information in the transaction CSV is the number of shares added, so the stock split ratio is calculated from that as `(existing_shares + added_shares) / existing_shares`.

Includes a unit test for the new `LotsDB.split()` method, and end-to-end tests both with and without lot details.