### PR TITLE
[schwab] trim account IDs for consistency across CSVs

### DIFF
--- a/beancount_import/source/schwab_csv_test.py
+++ b/beancount_import/source/schwab_csv_test.py
@@ -71,67 +71,67 @@ def dt(day: int) -> datetime.datetime:
 class TestLotsDB:
     def test_cost(self, db) -> None:
         db.load([lot(opened=1, cost="1.1"), lot(opened=2, cost="1.2")])
-        assert db.get_cost("Brokerage XX-12", "XX", d(2)) == D("1.2")
+        assert db.get_cost("XX-12", "XX", d(2)) == D("1.2")
 
     def test_cost_date_skew(self, db) -> None:
         db.load([lot(opened=1, cost="1.1"), lot(opened=2, cost="1.2")])
-        assert db.get_cost("Brokerage XX-12", "XX", d(3)) == D("1.2")
+        assert db.get_cost("XX-12", "XX", d(3)) == D("1.2")
 
     def test_cost_no_record(self, db) -> None:
-        assert db.get_cost("Brokerage XX-12", "XX", d(1)) is None
+        assert db.get_cost("XX-12", "XX", d(1)) is None
 
     def test_cost_no_match(self, db) -> None:
         db.load([lot(opened=2, cost="1.1"), lot(opened=3, cost="1.2")])
-        assert db.get_cost("Brokerage XX-12", "XX", d(1)) is None
+        assert db.get_cost("XX-12", "XX", d(1)) is None
 
     def test_cost_wrong_symbol(self, db) -> None:
         db.load([lot(opened=1, cost="1.1"), lot(opened=2, cost="1.2")])
-        assert db.get_cost("Brokerage XX-12", "YY", d(2)) is None
+        assert db.get_cost("XX-12", "YY", d(2)) is None
 
     def test_sale_lots(self, db) -> None:
         db.load([
             lot(asof=1, cost="1.1", quantity="10"),
             lot(asof=3, cost="1.1", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(2), D("3")) == {D("1.1"): D("3")}
+        assert db.get_sale_lots("XX-12", "XX", d(2), D("3")) == {D("1.1"): D("3")}
 
     def test_sale_lots_no_record(self, db) -> None:
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(2), D("3")) == {}
+        assert db.get_sale_lots("XX-12", "XX", d(2), D("3")) == {}
 
     def test_sale_lots_wrong_symbol(self, db) -> None:
         db.load([
             lot(asof=1, cost="1.1", quantity="10"),
             lot(asof=3, cost="1.1", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "YY", d(2), D("3")) == {}
+        assert db.get_sale_lots("XX-12", "YY", d(2), D("3")) == {}
 
     def test_sale_lots_too_early(self, db) -> None:
         db.load([
             lot(asof=2, cost="1.1", quantity="10"),
             lot(asof=3, cost="1.1", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(1), D("3")) == {}
+        assert db.get_sale_lots("XX-12", "XX", d(1), D("3")) == {}
 
     def test_sale_lots_too_late(self, db) -> None:
         db.load([
             lot(asof=1, cost="1.1", quantity="10"),
             lot(asof=3, cost="1.1", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(4), D("3")) == {}
+        assert db.get_sale_lots("XX-12", "XX", d(4), D("3")) == {}
 
     def test_sale_lots_insufficient_sold(self, db) -> None:
         db.load([
             lot(asof=1, cost="1.1", quantity="10"),
             lot(asof=3, cost="1.1", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(2), D("4")) == {}
+        assert db.get_sale_lots("XX-12", "XX", d(2), D("4")) == {}
 
     def test_sale_lots_additional_sold(self, db) -> None:
         db.load([
             lot(asof=1, cost="1.1", quantity="10"),
             lot(asof=3, cost="1.1", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(2), D("1")) == {}
+        assert db.get_sale_lots("XX-12", "XX", d(2), D("1")) == {}
 
     def test_sale_lots_multiple_candidates(self, db) -> None:
         db.load([
@@ -140,7 +140,7 @@ class TestLotsDB:
             lot(opened=2, asof=3, cost="1.2", quantity="10"),
             lot(opened=2, asof=5, cost="1.2", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(4), D("3")) == {}
+        assert db.get_sale_lots("XX-12", "XX", d(4), D("3")) == {}
 
     def test_sale_lots_split(self, db) -> None:
         db.load([
@@ -149,7 +149,7 @@ class TestLotsDB:
             lot(opened=2, asof=3, cost="1.2", quantity="10"),
             lot(opened=2, asof=5, cost="1.2", quantity="7"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(4), D("8")) == {
+        assert db.get_sale_lots("XX-12", "XX", d(4), D("8")) == {
             D("1.1"): D("5"),
             D("1.2"): D("3"),
         }
@@ -159,7 +159,7 @@ class TestLotsDB:
             lot(symbol="XX", asof=1, cost="1.1", quantity="5"),
             lot(symbol="YY", asof=3, cost="1.2", quantity="2"),
         ])
-        assert db.get_sale_lots("Brokerage XX-12", "XX", d(2), D("5")) == {D("1.1"): D("5")}
+        assert db.get_sale_lots("XX-12", "XX", d(2), D("5")) == {D("1.1"): D("5")}
 
     def test_split(self, db) -> None:
         db.load([
@@ -170,7 +170,7 @@ class TestLotsDB:
             lot(opened=2, asof=5, cost="2.0", quantity="10"),
             lot(opened=2, asof=7, cost="2.0", quantity="12"),
         ])
-        assert db.split("Brokerage XX-12", "XX", d(6), D("4")) == [
+        assert db.split("XX-12", "XX", d(6), D("4")) == [
             LotSplit(date=d(1), prev_cost=D("1.0"), prev_qty=D("6"), new_cost=D("0.8"), new_qty=D("7.50")),
             LotSplit(date=d(2), prev_cost=D("2.0"), prev_qty=D("10"), new_cost=D("1.6"), new_qty=D("12.50")),
         ]

--- a/testdata/source/schwab_csv/test_basic/journal.beancount
+++ b/testdata/source/schwab_csv/test_basic/journal.beancount
@@ -2,7 +2,7 @@
 1900-01-01 open Income:Capital-Gains:Schwab
 1900-01-01 open Expenses:Brokerage-Fees:Schwab
 1900-01-01 open Assets:Schwab:Brokerage-1234
-    schwab_account: "Brokerage XXXX-1234"
+    schwab_account: "XXXX-1234"
     div_income_account: "Income:Dividend:Schwab"
     interest_income_account: "Income:Interest:Schwab"
     capital_gains_account: "Income:Capital-Gains:Schwab"

--- a/testdata/source/schwab_csv/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV
@@ -1,4 +1,4 @@
-"Transactions  for account Intelligent XXXX-4321 as of 11/15/2020 18:01:20 ET"
+"Transactions  for account XXXX-4321 as of 11/15/2020 18:01:20 ET"
 "Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount",
 "11/14/2020 as of 11/13/2020","Stock Split","HYLB","XTRACKERS USD HIGH YIELDCOR BND ETF","18","$40.008","","",
 "11/10/2020","Journal","","JOURNAL FRM 00001234","","","","$123.45",


### PR DESCRIPTION
Previously we read the full account name from CSVs (e.g. `Brokerage XXXX-1234`) and used that as the account identifier. I'd previously observed that Lot details CSVs didn't use that full account name, just the `XXXX-1234` part, and so I'd added an ugly hack in the LotsDB code (the `convert_account` method) so the account names would match up. It now turns out (see #122) that sometimes other CSVs also don't use the full name. So this PR removes the hack from `LotsDB` and instead across the board uses only `XXXX-1234` account identifiers, stripping off the text before that when reading the accounts from CSV.

For backward compatibility I don't want to require people to update the `schwab_account` metadata on their Beancount accounts for things to keep working, so when we read that metadata from account meta we also trim it to just `XXXX-1234` if it says e.g. `Something XXXX-1234`.