### PR TITLE
generic_importer_source: Include entry in exceptions for context

### DIFF
--- a/beancount_import/source/generic_importer_source.py
+++ b/beancount_import/source/generic_importer_source.py
@@ -113,10 +113,10 @@ class ImporterSource(DescriptionBasedSource):
         if isinstance(entry, Balance):
             return (entry.account, entry.date, entry.amount)
         if not isinstance(entry, Transaction):
-            raise ValueError("currently, ImporterSource only supports Transaction and Balance Directive")
+            raise ValueError("currently, ImporterSource only supports Transaction and Balance Directive. Got entry {}".format(entry))
         source_posting = self._get_source_posting(entry)
         if source_posting is None:
-            raise ValueError("entry has no postings for account: {}".format(self.account))
+            raise ValueError("entry {} has no postings for account: {}".format(entry, self.account))
         return (self.account,
                 entry.date,
                 source_posting.units,


### PR DESCRIPTION
Show the entry in generic_importer_source exception error messages. Otherwise it's unclear what is causing an error.

Thanks again for providing this repo. As I use it more I'm further appreciating the import workflow it provides.