### PR TITLE
frontend: Display the specific posting account that is uncleared

### DIFF
--- a/frontend/server_connection.ts
+++ b/frontend/server_connection.ts
@@ -10,7 +10,7 @@ export type JournalError = [
 
 export interface UnclearedPosting {
   transaction: BeancountEntry;
-  posting: BeancountEntry;
+  posting: BeancountPosting;
   transaction_formatted: string;
 }
 

--- a/frontend/uncleared.tsx
+++ b/frontend/uncleared.tsx
@@ -61,7 +61,7 @@ export class UnclearedPostingComponent extends React.PureComponent<
     const { entry } = this.props;
     const filename = entry.transaction.meta && entry.transaction.meta.filename;
     const lineno = entry.transaction.meta && entry.transaction.meta.lineno;
-    
+    const account = entry.posting.account;
     const formattedText = entry.transaction_formatted;
     return (
       <AssociatedDataViewContext.Consumer>
@@ -73,8 +73,13 @@ export class UnclearedPostingComponent extends React.PureComponent<
                 {formattedText}
               </UnclearedPostingFormattedElement>
               {filename && <UnclearedPostingSource>
-                <em>File:</em> {filename}
-                {lineno !== undefined && `:${lineno}`}
+                <div>
+                  <em>Account:</em> {account}
+                </div>
+                <div>
+                  <em>File:</em> {filename}
+                  {lineno !== undefined && `:${lineno}`}
+                </div>
               </UnclearedPostingSource>}
             </UnclearedPostingElement>
           );
@@ -85,7 +90,7 @@ export class UnclearedPostingComponent extends React.PureComponent<
 
   private handleClick = () => {
     const { dataViewController } = this;
-    dataViewController!.selectFileByMeta(this.props.entry.posting.meta);
+    dataViewController!.selectFileByMeta(this.props.entry.transaction.meta);
   };
 }
 


### PR DESCRIPTION
I initially misunderstood how clearing worked and thought it applied to
a whole transaction. I had an account that I did not think any source
considered authoritative so I unsuccessfully tried to debug why a
different account and posting were not being cleared. If the specific
uncleared account was listed, as in this change, I would have
immediately understood the actual problem.

<img width="1237" alt="Screen Shot 2021-10-07 at 10 43 32 PM" src="https://user-images.githubusercontent.com/32316/136505450-17598c45-e5e4-43b5-8ed0-749d359f8680.png">
