### PR TITLE
Fix test failures on Windows (or anywhere libmagic is not installed.)

### DIFF
--- a/beancount_import/source/generic_importer_source.py
+++ b/beancount_import/source/generic_importer_source.py
@@ -58,7 +58,7 @@ class ImporterSource(DescriptionBasedSource):
 
     def prepare(self, journal: 'JournalEditor', results: SourceResults) -> None:
         results.add_account(self.account)
-        
+
         entries = OrderedDict() #type: Dict[Hashable, List[Directive]]
         for f in self.files:
             f_entries = self.importer.extract(f, existing_entries=journal.entries)
@@ -135,8 +135,12 @@ class ImporterSource(DescriptionBasedSource):
 
 
 def get_info(raw_entry: Directive) -> dict:
+    if raw_entry.meta["filename"].endswith(".beancount"):
+        ftype = "text/plain"
+    else:
+        ftype = get_file(raw_entry.meta['filename']).mimetype()
     return dict(
-        type=get_file(raw_entry.meta['filename']).mimetype(),
+        type=ftype,
         filename=raw_entry.meta['filename'],
         line=raw_entry.meta['lineno'],
     )


### PR DESCRIPTION
#131 reintroduced a case of the generic-importer tests trying to guess the mimetype of a beancount file, which fails if libmagic is not installed. This is now showing up on new PRs (eg #135 ) as failures of the Windows tests, which don't have libmagic; not sure why this didn't get caught on the PR itself.

This fixes it by explicitly adding support to the generic importer to recognize beancount files as `text/plain`, which matches what libmagic guesses anyway.