### PR TITLE
A merged posting is implicitly cleared.

### DIFF
--- a/beancount_import/source/description_based_source.py
+++ b/beancount_import/source/description_based_source.py
@@ -129,4 +129,6 @@ class DescriptionBasedSource(Source):
     def is_posting_cleared(self, posting: Posting):
         if posting.meta is None:
             return False
+        if posting.meta.get("merge"):
+            return True
         return not MATCHED_METADATA_KEYS.isdisjoint(posting.meta)

--- a/beancount_import/source/description_based_source_test.py
+++ b/beancount_import/source/description_based_source_test.py
@@ -1,0 +1,20 @@
+import unittest
+
+from beancount.core.amount import Amount
+from beancount.core.data import Posting
+from beancount.core.number import D
+
+from .description_based_source import DescriptionBasedSource
+
+
+class DescriptionBasedSourceTest(unittest.TestCase):
+    def test_merged_posting_is_cleared(self):
+        postings = [
+            Posting(account="a", units=Amount(D(10), "USD"), cost=None,
+                    price=None, flag=None, meta=None),
+            Posting(account="a", units=Amount(D(10), "USD"), cost=None,
+                    price=None, flag=None, meta={"merge": True}),
+        ]
+        source = DescriptionBasedSource(lambda s: None)
+        self.assertEqual(source.is_posting_cleared(postings[0]), False)
+        self.assertEqual(source.is_posting_cleared(postings[1]), True)


### PR DESCRIPTION
#110 introduced `merge: TRUE` metadata which can be used on manually booked lots from import sources that don't have unique transaction IDs, so that unbook can re-merge them and they'll match the un-split imported posting.

A posting with `merge: TRUE` should also be implicitly considered cleared, because it is really part of the posting above that it merges with. If the merged-with posting is uncleared, it will show up as such and we don't need both postings showing up as uncleared. If the merged-with posting is cleared, then the merged one is too.

Without this we have to manually add `cleared: TRUE` to every posting with `merge: TRUE` once its merged-with posting has cleared.