### PR TITLE
[schwab_csv] resolve lot asof to nearest day.

### DIFF
--- a/beancount_import/source/schwab_csv_test.py
+++ b/beancount_import/source/schwab_csv_test.py
@@ -52,7 +52,7 @@ def lot(
     return RawLot(
         symbol=symbol,
         account=account,
-        asof=dt(asof),
+        asof=d(asof),
         opened=dt(opened),
         quantity=D(quantity),
         price=D(price),

--- a/testdata/source/schwab_csv/test_lots/positions/lots/2020-09-25/FNDA.csv
+++ b/testdata/source/schwab_csv/test_lots/positions/lots/2020-09-25/FNDA.csv
@@ -1,4 +1,4 @@
-"FNDA Lot Details for XXXX-4321 as of 02:45 AM ET, 09/25/2020"
+"FNDA Lot Details for XXXX-4321 as of 02:46 AM ET, 09/25/2020"
 
 "Open Date","Quantity","Price","Cost/Share","Market Value","Cost Basis","Gain/Loss $","Gain/Loss %","Holding Period",
 "08/24/2020 13:22:52","1","$33.89","$34.89","$33.89","$34.89","-$1.00","-2.9%","Short Term",


### PR DESCRIPTION
The auto-lot-split logic relies on grouping all lot details downloaded at the same time and assuming they are complete for that point in time; any missing lot-details CSV for a commodity will result in an assumption that zero units of that commodity were held at that point in time.

But each lot details CSV will be downloaded a second or two after the one before it, even when using finance-dl to automate the download, and this could cross a minute boundary. Then we will have some lot details downloaded at minute X and some at minute X+1; these will be treated as downloaded at a different point in time, splitting what should have been one point-in-time into two, each with many missing commodities.

This PR resolves this by truncating the asof-datetime to just the date, so all lot details downloaded on the same date will be considered the same point in time.

The original problem could still occur if lot details are downloaded at exactly midnight, but this seems unlikely and I don't see a way to avoid that.