### PR TITLE
[schwab_csv] handle extended lot-details CSV format.

### DIFF
--- a/beancount_import/source/schwab_csv_test.py
+++ b/beancount_import/source/schwab_csv_test.py
@@ -53,7 +53,7 @@ def lot(
         symbol=symbol,
         account=account,
         asof=d(asof),
-        opened=dt(opened),
+        opened=d(opened),
         quantity=D(quantity),
         price=D(price),
         cost=D(cost),

--- a/testdata/source/schwab_csv/test_lots/positions/lots/2020-10-25/HYLB.csv
+++ b/testdata/source/schwab_csv/test_lots/positions/lots/2020-10-25/HYLB.csv
@@ -1,6 +1,6 @@
 "HYLB Lot Details for XXXX-4321 as of 02:45 AM ET, 10/25/2020"
 
-"Open Date","Quantity","Price","Cost/Share","Market Value","Cost Basis","Gain/Loss $","Gain/Loss %","Holding Period",
-"08/31/2020 13:42:07","24","$1.00","$5.00","$24.00","$120.00","$0.00","+0.00%","Short Term",
-"08/30/2020 13:42:07","16","$1.00","$10.00","$16.00","$160.00","$0.00","+0.00%","Short Term",
-"Total","20","--","--","$40.00","$280.00","$0.00","+0.00%","--",
+"Open Date","Transaction Open","Quantity","Price","Cost/Share","Transaction CPS","Market Value","Cost Basis","Transaction CB","Gain/Loss $","Transaction G/L $","Gain/Loss %","Transaction G/L %","Holding Period","Disallowed Loss",
+"08/31/2020 00:00:00","--","24","$1.00","$5.00","$24.00","--","$120.00","$0.00","--","+0.00%","--","Short Term","--",
+"08/30/2020 13:42:07","--","16","$1.00","$10.00","$16.00","--","$160.00","$0.00","--","+0.00%","--","Short Term","--",
+"Total","--","20","--","--","--","$40.00","$280.00","--","$0.00","--","+0.00%","--","--","--",


### PR DESCRIPTION
When a lot has disallowed loss, Schwab renders the lot-details CSV for that commodity in an extended format. This PR handles that extended format.

In some cases (I'm not sure if related to above or not) the time portion of a lot open date is zeroed out, when in previous lot details a time was included for that lot. Handle this by tracking lot open date simply as a date, not as a datetime.