### PR TITLE
Schwab: add support for past year dividend reinvest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ beancount_import/frontend_dist/*.map
 .coverage
 htmlcov/
 .eggs/
+.idea/

--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -170,6 +170,7 @@ class BrokerageAction(enum.Enum):
     MISC_CASH_ENTRY = "Misc Cash Entry"
     MONEYLINK_TRANSFER = "MoneyLink Transfer"
     PRIOR_YEAR_CASH_DIVIDEND = "Pr Yr Cash Div"
+    PRIOR_YEAR_DIV_REINVEST = "Pr Yr Div Reinvest"
     PRIOR_YEAR_SPECIAL_DIVIDEND = "Pr Yr Special Div"
     PROMOTIONAL_AWARD = "Promotional Award"
     QUAL_DIV_REINVEST = "Qual Div Reinvest"
@@ -321,6 +322,7 @@ class RawBrokerageEntry(RawEntry):
             BrokerageAction.CASH_DIVIDEND,
             BrokerageAction.CASH_IN_LIEU,
             BrokerageAction.PRIOR_YEAR_CASH_DIVIDEND,
+            BrokerageAction.PRIOR_YEAR_DIV_REINVEST,
             BrokerageAction.PRIOR_YEAR_SPECIAL_DIVIDEND,
             BrokerageAction.SPECIAL_DIVIDEND,
             BrokerageAction.QUALIFIED_DIVIDEND,

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ setuptools.setup(
         'atomicwrites>=1.3.0',
         'jsonschema',
         'watchdog',
+        'typing_extensions',
     ],
     test_requirements=[
         'pytest',

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -887,3 +887,14 @@
     schwab_action: "DEPOSIT"
     source_desc: "Deposit Mobile Banking"
   Expenses:FIXME          -1234.56 USD
+
+;; date: 2022-04-20
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 20, "type": "text/csv"}
+
+; features: []
+2022-04-20 * "INCOME - DIV - ISHARES GLOBAL CLEAN ENERGY ETF"
+  Assets:Schwab:Brokerage-1234:Cash   2.11 USD
+    date: 2022-04-20
+    schwab_action: "Pr Yr Div Reinvest"
+    source_desc: "ISHARES GLOBAL CLEAN ENERGY ETF"
+  Income:Dividend:Schwab:ICLN        -2.11 USD

--- a/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV
@@ -18,4 +18,5 @@
 "02/16/2021 as of 02/15/2021","Bond Interest","912810SP4","US TREASURY 1.375%08/50UST BOND DUE 08/15/50","","","","$6.87",
 "03/25/2021","Stock Merger","QQZ","QUQUZETA CORP","100","","","",
 "03/25/2021","Stock Merger","SPAC1","SPAC MERGER CORP XXXMANDATORY MERGER EFF: 03/25/21","-100","","",""
+"04/20/2022","Pr Yr Div Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
 Transactions Total,"","","","","","",$0.00


### PR DESCRIPTION
this PR fixes a couple errors I've run into when trying to import my Schwab transactions.

mainly tried to get the import to work and tests to pass, open to any feedback