### PR TITLE
Schwab: add missing brokerage actions (cap gain reinvests, moneylink deposit)

### DIFF
--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -165,9 +165,11 @@ class BrokerageAction(enum.Enum):
     JOURNAL = "Journal"
     JOURNALED_SHARES = "Journaled Shares"
     LONG_TERM_CAP_GAIN = "Long Term Cap Gain"
+    LONG_TERM_CAP_GAIN_REINVEST = "Long Term Cap Gain Reinvest"
     MARGIN_INTEREST = "Margin Interest"
     CREDIT_INTEREST = "Credit Interest"
     MISC_CASH_ENTRY = "Misc Cash Entry"
+    MONEYLINK_DEPOSIT = "MoneyLink Deposit"
     MONEYLINK_TRANSFER = "MoneyLink Transfer"
     PRIOR_YEAR_CASH_DIVIDEND = "Pr Yr Cash Div"
     PRIOR_YEAR_DIV_REINVEST = "Pr Yr Div Reinvest"
@@ -185,6 +187,7 @@ class BrokerageAction(enum.Enum):
     SELL_TO_OPEN = "Sell to Open"
     SERVICE_FEE = "Service Fee"
     SHORT_TERM_CAP_GAIN = "Short Term Cap Gain"
+    SHORT_TERM_CAP_GAIN_REINVEST = "Short Term Cap Gain Reinvest"
     SPECIAL_DIVIDEND = "Special Dividend"
     STOCK_MERGER = "Stock Merger"
     STOCK_PLAN_ACTIVITY = "Stock Plan Activity"
@@ -329,6 +332,8 @@ class RawBrokerageEntry(RawEntry):
             BrokerageAction.NON_QUALIFIED_DIVIDEND,
             BrokerageAction.QUAL_DIV_REINVEST,
             BrokerageAction.REINVEST_DIVIDEND,
+            BrokerageAction.LONG_TERM_CAP_GAIN_REINVEST,
+            BrokerageAction.SHORT_TERM_CAP_GAIN_REINVEST,
         ):
             return CashDividend(
                 symbol=self.symbol,
@@ -359,6 +364,7 @@ class RawBrokerageEntry(RawEntry):
                 **shared_attrs,
             )
         if self.action in (BrokerageAction.MONEYLINK_TRANSFER,
+                           BrokerageAction.MONEYLINK_DEPOSIT,
                            BrokerageAction.JOURNAL,
                            BrokerageAction.JOURNALED_SHARES,
                            BrokerageAction.SECURITY_TRANSFER,

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -856,6 +856,27 @@
     source_desc: "ISHARES GOLD ETF"
   Income:Dividend:Schwab:IAU           -18.02 USD
 
+;; date: 2021-05-26
+;; info: {"filename": "<testdata>/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV", "line": 26, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "2000.00 USD",
+;               "date": "2021-05-26",
+;               "key_value_pairs": {
+;                 "desc": "Tfr SOME BANK",
+;                 "schwab_action": "MoneyLink Deposit"
+;               },
+;               "source_account": "Assets:Schwab:Intelligent-4321:Cash"
+;             }
+;           ]
+2021-05-26 * "TRANSFER - Tfr SOME BANK"
+  Assets:Schwab:Intelligent-4321:Cash   2000.00 USD
+    date: 2021-05-26
+    schwab_action: "MoneyLink Deposit"
+    source_desc: "Tfr SOME BANK"
+  Expenses:FIXME                       -2000.00 USD
+
 ;; date: 2021-07-30
 ;; info: {"filename": "<testdata>/test_basic/transactions/EAC_Checking_Transactions_20201223-160009.CSV", "line": 5, "type": "text/csv"}
 
@@ -896,5 +917,27 @@
   Assets:Schwab:Brokerage-1234:Cash   2.11 USD
     date: 2022-04-20
     schwab_action: "Pr Yr Div Reinvest"
+    source_desc: "ISHARES GLOBAL CLEAN ENERGY ETF"
+  Income:Dividend:Schwab:ICLN        -2.11 USD
+
+;; date: 2022-04-21
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 21, "type": "text/csv"}
+
+; features: []
+2022-04-21 * "INCOME - DIV - ISHARES GLOBAL CLEAN ENERGY ETF"
+  Assets:Schwab:Brokerage-1234:Cash   2.11 USD
+    date: 2022-04-21
+    schwab_action: "Long Term Cap Gain Reinvest"
+    source_desc: "ISHARES GLOBAL CLEAN ENERGY ETF"
+  Income:Dividend:Schwab:ICLN        -2.11 USD
+
+;; date: 2022-04-22
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 22, "type": "text/csv"}
+
+; features: []
+2022-04-22 * "INCOME - DIV - ISHARES GLOBAL CLEAN ENERGY ETF"
+  Assets:Schwab:Brokerage-1234:Cash   2.11 USD
+    date: 2022-04-22
+    schwab_action: "Short Term Cap Gain Reinvest"
     source_desc: "ISHARES GLOBAL CLEAN ENERGY ETF"
   Income:Dividend:Schwab:ICLN        -2.11 USD

--- a/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV
@@ -19,4 +19,6 @@
 "03/25/2021","Stock Merger","QQZ","QUQUZETA CORP","100","","","",
 "03/25/2021","Stock Merger","SPAC1","SPAC MERGER CORP XXXMANDATORY MERGER EFF: 03/25/21","-100","","",""
 "04/20/2022","Pr Yr Div Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
+"04/21/2022","Long Term Cap Gain Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
+"04/22/2022","Short Term Cap Gain Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
 Transactions Total,"","","","","","",$0.00

--- a/testdata/source/schwab_csv/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Intelligent_Transactions_20201115-180120.CSV
@@ -24,4 +24,5 @@
 "02/16/2021","Journaled Shares","GOOG","ALPHABET INC. CLASS C","-12.3456","$2134.20","","",
 "03/22/2021","Security Transfer","GOOG","ALPHABET INC. CLASS C","-10","","","",
 "05/25/2021","Cash In Lieu","IAU","ISHARES GOLD ETF","","","","$18.02",
+"05/26/2021","MoneyLink Deposit","","Tfr SOME BANK","","","","$2000.00",
 Transactions Total,"","","","","","",-$9620.64


### PR DESCRIPTION
these are the last actions missing for import to work w/ my schwab transactions