### PR TITLE
[Paypal] correct fee sign for fees on SEND_MONEY_RECEIVED

### DIFF
--- a/beancount_import/source/paypal.py
+++ b/beancount_import/source/paypal.py
@@ -480,7 +480,10 @@ class PaypalSource(LinkBasedSource, Source):
 
 
         if fee_amount.number != ZERO:
-            if negate_counterparty_amounts and transaction_type_enum != 'EBAY_SALE':
+            if (negate_counterparty_amounts
+                and transaction_type_enum != 'EBAY_SALE'
+                and not transaction_type_enum.endswith('_RECEIVED')
+            ):
                 amount = -fee_amount
             else:
                 amount = fee_amount


### PR DESCRIPTION
Hello,

I stumbled upon an issue where the fees of a `SEND_MONEY_RECEIVED` transaction were considered with the wrong sign. I think for all `_RECEIVED` type transactions the fee sign should not be negated.

```
"transactionTypeEnum": "SEND_MONEY_RECEIVED",
"transactionType": "Geld erhalten",
...
"amount": {
    "grossAmount": "51,50\u00a0EUR",
    "netAmount": "49,87\u00a0EUR",
    "fullPageNetAmount": "49,87",
    "feeAmount": "1,63\u00a0EUR",
    "grossExceedsNet": true,
    "isZeroFee": false,
    "feeLabel": "Geb\u00fchr",
    "rawAmounts": {
      "gross": {
        "value": "51.5",
        "currencyCode": "EUR"
      }
    }
  },
```

The current code does:

```
elif transaction_type_enum.endswith('_RECEIVED'):
            negate_funding_source_amounts = False
```
and
```
negate_counterparty_amounts = not negate_funding_source_amounts
```
So `funding_source_amount` is not negated but `counterparty_amount`. The `fee_amount` is also negated, since it is coupled to `negate_counterparty_amounts`. This is wrong since it needs to account **against** the `counterparty_amount`.

In case of the example, the output should be similar to this:
```
Expenses:Financial:Paypal:Fees    1.63 EUR
Expenses:FIXME:A                -51.50 EUR
    paypal_counterparty: "John Doe"
    paypal_counterparty_email: "johndoe@gmail.com"
    paypal_note: "iMac 27“ Parts"
 Assets:Paypal                    49.87 EUR
    date: 2022-03-14
    paypal_transaction_id: "N40EZGDXBEFI1O3SA"
```

I added a testcase in #142. Since my example data is in german, it requires the proposed `de_DE` locale functionality and it makes no sense to be added here.

But I thought I keep this change separate for traceability and discussion.

All existing tests work fine with the changes proposed here.

I'm happy for your thoughts!