### PR TITLE
[Venmo] Handle new transaction type - "Merchant Transaction".

### DIFF
--- a/testdata/source/venmo/test_basic/import_results.beancount
+++ b/testdata/source/venmo/test_basic/import_results.beancount
@@ -345,3 +345,75 @@
     venmo_transfer_id: "7315187729"
     venmo_type: "Standard Transfer"
   Expenses:FIXME   1341.23 USD
+
+;; date: 2022-01-09
+;; info: {"filename": "<testdata>/transactions.csv", "line": 10, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-2.24 USD",
+;               "date": "2022-01-09",
+;               "key_value_pairs": {
+;                 "venmo_description": "Local Eats",
+;                 "venmo_payee": "Charlie Chow",
+;                 "venmo_type": "Merchant Transaction"
+;               },
+;               "source_account": "Assets:Venmo"
+;             }
+;           ]
+2022-01-09 * "Charlie Chow" "Local Eats"
+  Assets:Venmo    -2.24 USD
+    date: 2022-01-09
+    venmo_description: "Local Eats"
+    venmo_payee: "Charlie Chow"
+    venmo_payment_id: "1291991306506600548"
+    venmo_type: "Merchant Transaction"
+  Expenses:FIXME   2.24 USD
+
+;; date: 2022-02-18
+;; info: {"filename": "<testdata>/transactions.csv", "line": 11, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "22.84 USD",
+;               "date": "2022-02-18",
+;               "key_value_pairs": {
+;                 "venmo_account_description": "Bank Checking*1234",
+;                 "venmo_type": "Merchant Transaction"
+;               },
+;               "source_account": "Assets:Venmo"
+;             }
+;           ]
+2022-02-18 * "Charlie Chow" "Transfer" ^venmo.1299175267271967461
+  Assets:Venmo     22.84 USD
+    date: 2022-02-18
+    venmo_account_description: "Bank Checking*1234"
+    venmo_description: "Distant Treats"
+    venmo_payee: "Charlie Chow"
+    venmo_transfer_id: "1299175267271967461"
+    venmo_type: "Merchant Transaction"
+  Expenses:FIXME  -22.84 USD
+
+;; date: 2022-02-18
+;; info: {"filename": "<testdata>/transactions.csv", "line": 11, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-22.84 USD",
+;               "date": "2022-02-18",
+;               "key_value_pairs": {
+;                 "venmo_description": "Distant Treats",
+;                 "venmo_payee": "Charlie Chow",
+;                 "venmo_type": "Merchant Transaction"
+;               },
+;               "source_account": "Assets:Venmo"
+;             }
+;           ]
+2022-02-18 * "Charlie Chow" "Distant Treats" ^venmo.1299175267271967461
+  Assets:Venmo    -22.84 USD
+    date: 2022-02-18
+    venmo_description: "Distant Treats"
+    venmo_payee: "Charlie Chow"
+    venmo_payment_id: "1299175267271967461"
+    venmo_type: "Merchant Transaction"
+  Expenses:FIXME   22.84 USD

--- a/testdata/source/venmo/test_invalid_references/journal.beancount
+++ b/testdata/source/venmo/test_invalid_references/journal.beancount
@@ -142,3 +142,34 @@ plugin "beancount.plugins.auto_accounts"
     venmo_type: "Standard Transfer"
     cleared: TRUE
   Expenses:FIXME   1341.23 USD
+
+2022-01-09 * "Charlie Chow" "Local Eats"
+  Assets:Venmo    -2.24 USD
+    date: 2022-01-09
+    venmo_description: "Local Eats"
+    venmo_payee: "Charlie Chow"
+    venmo_payment_id: "1291991306506600548"
+    venmo_type: "Merchant Transaction"
+    cleared: TRUE
+  Expenses:FIXME   2.24 USD
+
+2022-02-18 * "Charlie Chow" "Transfer" ^venmo.1299175267271967461
+  Assets:Venmo     22.84 USD
+    date: 2022-02-18
+    venmo_account_description: "Bank Checking*1234"
+    venmo_description: "Distant Treats"
+    venmo_payee: "Charlie Chow"
+    venmo_transfer_id: "1299175267271967461"
+    venmo_type: "Merchant Transaction"
+    cleared: TRUE
+  Expenses:FIXME  -22.84 USD
+
+2022-02-18 * "Charlie Chow" "Distant Treats" ^venmo.1299175267271967461
+  Assets:Venmo    -22.84 USD
+    date: 2022-02-18
+    venmo_description: "Distant Treats"
+    venmo_payee: "Charlie Chow"
+    venmo_payment_id: "1299175267271967461"
+    venmo_type: "Merchant Transaction"
+    cleared: TRUE
+  Expenses:FIXME   22.84 USD

--- a/testdata/source/venmo/test_matching/journal.beancount
+++ b/testdata/source/venmo/test_matching/journal.beancount
@@ -131,3 +131,35 @@ plugin "beancount.plugins.auto_accounts"
     venmo_type: "Standard Transfer"
     cleared: TRUE
   Assets:Checking   1341.23 USD
+  
+2022-01-09 * "Charlie Chow" "Local Eats"
+  Assets:Venmo    -2.24 USD
+    date: 2022-01-09
+    venmo_description: "Local Eats"
+    venmo_payee: "Charlie Chow"
+    venmo_payment_id: "1291991306506600548"
+    venmo_type: "Merchant Transaction"
+    cleared: TRUE
+  Expenses:FIXME   2.24 USD
+
+2022-02-18 * "Charlie Chow" "Transfer" ^venmo.1299175267271967461
+  Assets:Venmo     22.84 USD
+    date: 2022-02-18
+    venmo_account_description: "Bank Checking*1234"
+    venmo_description: "Distant Treats"
+    venmo_payee: "Charlie Chow"
+    venmo_transfer_id: "1299175267271967461"
+    venmo_type: "Merchant Transaction"
+    cleared: TRUE
+  Expenses:FIXME  -22.84 USD
+
+2022-02-18 * "Charlie Chow" "Distant Treats" ^venmo.1299175267271967461
+  Assets:Venmo    -22.84 USD
+    date: 2022-02-18
+    venmo_description: "Distant Treats"
+    venmo_payee: "Charlie Chow"
+    venmo_payment_id: "1299175267271967461"
+    venmo_type: "Merchant Transaction"
+    cleared: TRUE
+  Expenses:FIXME   22.84 USD
+    

--- a/testdata/source/venmo/transactions.csv
+++ b/testdata/source/venmo/transactions.csv
@@ -8,3 +8,5 @@
 "3083645406127028805","2018-05-01T14:49:07","Payment","Complete","Rent","Sally Smith","Brian Taylor","+ $1,423.73","","","Venmo balance"
 "1326234690911981511","2018-05-19T00:08:52","Charge","Complete","Utilities","Maria Anderson","Brian Taylor","- $82.50","","Venmo balance",""
 "7315187729","2018-05-19T00:09:15","Standard Transfer","Issued","","","","- $1,341.23","","","Visa Debit *8967"
+"1291991306506600548",2022-01-09T01:59:03,"Merchant Transaction","Complete","","Charlie Chow","Local Eats","- $2.24","","Venmo balance",""
+"1299175267271967461",2022-02-18T23:24:55,"Merchant Transaction","Complete","","Charlie Chow","Distant Treats","- $22.84","","Bank Checking*1234",""


### PR DESCRIPTION
I've seen `Merchant Transaction` appear among my transactions. Venmo seems to apply this to some in-app payments (e.g. Uber Eats).