### PR TITLE
Generic Importer: Respect tolerance during balancing

### DIFF
--- a/beancount_import/source/generic_importer_source.py
+++ b/beancount_import/source/generic_importer_source.py
@@ -18,14 +18,12 @@ from collections import OrderedDict
 import itertools
 from typing import Hashable, List, Dict, Optional
 
-from beancount.core.data import Balance, Transaction, Posting,  Directive
-from beancount.core.amount import Amount
-from beancount.core.convert import get_weight
+from beancount.core import interpolate
+from beancount.core.data import Balance, Transaction, Posting,  Directive, Options
 from beancount.ingest.importer import ImporterProtocol
 from beancount.ingest.cache import get_file
-from beancount.parser.booking_full import convert_costspec_to_cost
 
-from ..matching import FIXME_ACCOUNT, SimpleInventory
+from ..matching import FIXME_ACCOUNT
 from . import ImportResult, SourceResults
 from ..journal_editor import JournalEditor
 from .description_based_source import DescriptionBasedSource, get_pending_and_invalid_entries
@@ -83,7 +81,7 @@ class ImporterSource(DescriptionBasedSource):
             account_set=set([self.account]),
             get_key_from_posting=_get_key_from_posting,
             get_key_from_raw_entry=self._get_key_from_imported_entry,
-            make_import_result=self._make_import_result,
+            make_import_result=lambda entry: self._make_import_result(entry,journal.options_map),
             results=results)
 
     def _add_description(self, entry: Transaction):
@@ -124,8 +122,9 @@ class ImporterSource(DescriptionBasedSource):
                 source_posting.units,
                 entry.narration)
 
-    def _make_import_result(self, imported_entry:Directive):
-        if isinstance(imported_entry, Transaction): balance_amounts(imported_entry)
+    def _make_import_result(self, imported_entry: Directive, options_map: Options):
+        if isinstance(imported_entry, Transaction):
+            balance_amounts(imported_entry, options_map)
         result = ImportResult(
             date=imported_entry.date, info=get_info(imported_entry), entries=[imported_entry])
         # delete filename since it is used by beancount-import to determine if the
@@ -145,21 +144,24 @@ def get_info(raw_entry: Directive) -> dict:
         line=raw_entry.meta['lineno'],
     )
 
-def balance_amounts(txn:Transaction)-> None:
+
+def balance_amounts(txn: Transaction, options_map: Options) -> None:
     """Add FIXME account for the remaing amount to balance accounts"""
-    inventory = SimpleInventory()
-    for posting in txn.postings:
-        inventory += get_weight(convert_costspec_to_cost(posting))
-    for currency in inventory:
+    residual = interpolate.compute_residual(txn.postings)
+    tolerances = interpolate.infer_tolerances(txn.postings, options_map)
+    if residual.is_small(tolerances):
+        return
+    for position in residual:
         txn.postings.append(
             Posting(
                 account=FIXME_ACCOUNT,
-                units=Amount(currency=currency, number=-inventory[currency]),
+                units=-position.units,
                 cost=None,
                 price=None,
                 flag=None,
                 meta={},
-            ))
+            )
+        )
 
 
 def load(spec, log_status):

--- a/testdata/source/generic_importer/test_cost/import_results.beancount
+++ b/testdata/source/generic_importer/test_cost/import_results.beancount
@@ -7,3 +7,13 @@
     date: 2020-01-01
     source_desc: "convert currency"
   Assets:Saving   2 EUR @ 0.5 USD
+
+;; date: 2020-01-02
+;; info: {"filename": "<testdata>/test_cost/input/generic_statement.beancount", "line": 6, "type": "text/plain"}
+
+; features: []
+2020-01-02 * "convert currency with a rounding error"
+  Assets:Bank    -1.00 USD
+    date: 2020-01-02
+    source_desc: "convert currency with a rounding error"
+  Assets:Saving   3.00 EUR @ 0.3333 USD

--- a/testdata/source/generic_importer/test_cost/input/generic_statement.beancount
+++ b/testdata/source/generic_importer/test_cost/input/generic_statement.beancount
@@ -2,3 +2,7 @@
 2020-01-01 * "convert currency"
   Assets:Bank     -1 USD
   Assets:Saving     2 EUR @@ 1USD
+
+2020-01-02 * "convert currency with a rounding error"
+  Assets:Bank      -1.00 USD
+  Assets:Saving     3.00 EUR @ 0.3333 USD


### PR DESCRIPTION
Account for rounding errors by adding Expenses:FIXME posting only when the amount is smaller then the deduced/configured tolerance.

Without this change the added test case would have received a posting `Expenses:FIXME 0.000100 USD`.