### PR TITLE
rename_account.py: Fix beancount.core.prices import

### DIFF
--- a/beancount_import/rename_account.py
+++ b/beancount_import/rename_account.py
@@ -7,8 +7,7 @@ from beancount.query import (query_compile, query_env, query_execute, query_pars
 from beancount.core import inventory
 from beancount.core.data import Transaction
 from beancount.parser import options
-from beancount.core import getters
-from beancount.ops import prices
+from beancount.core import (getters, prices)
 from . import journal_editor
 import pdb
 


### PR DESCRIPTION
`beancount.ops.prices` was [renamed](https://github.com/beancount/beancount/commit/5a818e4786e2dd44d062b3b41f5f077c8a6c6dd5) to `beancount.core.prices` in 2016, resulting in the following error:

```
$ python3 -m beancount_import.rename_account
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.10/3.10.6_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/Cellar/python@3.10/3.10.6_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.10/site-packages/beancount_import/rename_account.py", line 11, in <module>
    from beancount.ops import prices
ImportError: cannot import name 'prices' from 'beancount.ops' (/usr/local/lib/python3.10/site-packages/beancount/ops/__init__.py)
```

After fixing the import, the command runs successfully:

```
$ python3 -m beancount_import.rename_account
usage: rename_account.py [-h] [-a NEW_ACCOUNT] [-e EVAL] journal query
rename_account.py: error: the following arguments are required: journal, query
```