### PR TITLE
fix: replace `get_feature_names` with `get_feature_names_out` for scikit-learn classifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
           - 'windows-latest'
           - 'macos-latest'
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
         node-version:
           - '15.x'
     runs-on: ${{ matrix.os }}

--- a/beancount_import/reconcile.py
+++ b/beancount_import/reconcile.py
@@ -136,7 +136,7 @@ def get_prediction_explanation(classifier, features: Dict[str, bool]):
 
     converted_features = classifier._vectorizer.transform([features])
     class_names = classifier._encoder.classes_
-    feature_names = classifier._vectorizer.get_feature_names()
+    feature_names = classifier._vectorizer.get_feature_names_out()
 
     node_id = 0
     while True:

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ setuptools.setup(
         'tornado',
         'numpy',
         'scipy',
-        'scikit-learn',
+        'scikit-learn~=1.2',
         'nltk',
         'python-dateutil',
         'atomicwrites>=1.3.0',

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ setuptools.setup(
     package_data={
         'beancount_import': ['frontend_dist/*'],
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     setup_requires=['setuptools_scm>=5.0.2'],
     install_requires=[
         'beancount>=2.1.3',


### PR DESCRIPTION
I'm not sure exactly how this broke for me as this worked perfectly fine for me a month ago - perhaps a system update updated `scikit-learn`. 

It seems `scikit-learn 1.2.0`  uses `get_feature_names_out` for the classifier instead of:

 https://github.com/jbms/beancount-import/blob/afd3093ff3e1cf35663f0ba170e2f94451fc90b0/beancount_import/reconcile.py#L139

At least the commit I made was necessary for it to work on my machine. I made this change for myself and all seems to work - presumably it's needed here so I thought to make the PR.