### PR TITLE
make parse_amount work with currency symbols after amount

### DIFF
--- a/beancount_import/amount_parsing.py
+++ b/beancount_import/amount_parsing.py
@@ -30,7 +30,7 @@ def parse_amount(x, assumed_currency=None):
     if not x:
         return None
     sign, amount_str = parse_possible_negative(x)
-    m = re.fullmatch(r'(?:[(][^)]+[)])?\s*([\$€£]|[A-Z]{3})?\s*((?:[0-9](?:,?[0-9])*|(?=\.))(?:\.[0-9]+)?)(?:\s+([A-Z]{3}))?', amount_str)
+    m = re.fullmatch(r'(?:[(][^)]+[)])?\s*([\$€£]|[A-Z]{3})?\s*((?:[0-9](?:,?[0-9])*|(?=\.))(?:\.[0-9]+)?)(?:\s+([\$€£]|[A-Z]{3}))?', amount_str)
     if m is None:
         raise ValueError('Failed to parse amount from %r' % amount_str)
     if m.group(1):
@@ -42,7 +42,11 @@ def parse_amount(x, assumed_currency=None):
             currency = {'$': 'USD', '€': 'EUR', '£': 'GBP'}[m.group(1)]
     elif m.group(3):
         # unit after amount
-        currency = m.group(3)
+        if len(m.group(3)) == 3:
+            # 'EUR' or 'USD'
+            currency = m.group(3)
+        else:
+            currency = {'$': 'USD', '€': 'EUR', '£': 'GBP'}[m.group(3)]
     elif assumed_currency is not None:
         currency = assumed_currency
     else:

--- a/beancount_import/source/amazon.py
+++ b/beancount_import/source/amazon.py
@@ -545,8 +545,8 @@ class AmazonSource(Source):
                  directory: str,
                  amazon_account: str,
                  posttax_adjustment_accounts: Dict[str, str] = {},
-                 pickle_dir: str = None,
-                 earliest_date: datetime.date = None,
+                 pickle_dir: Optional[str] = None,
+                 earliest_date: Optional[datetime.date] = None,
                  locale='en_US',
                  **kwargs) -> None:
         super().__init__(**kwargs)

--- a/beancount_import/source/paypal.py
+++ b/beancount_import/source/paypal.py
@@ -420,7 +420,7 @@ class PaypalSource(LinkBasedSource, Source):
                  assets_account: str,
                  fee_account: str,
                  prefix: str,
-                 earliest_date: datetime.date = None,
+                 earliest_date: Optional[datetime.date] = None,
                  locale: str='en_US',
                  **kwargs) -> None:
         super().__init__(link_prefix=prefix + '.', **kwargs)


### PR DESCRIPTION
also allow symbols after the amount (currently only 3 letter currency possible)
allows e.g. `2.99 €` instead of `2.99 EUR`

required since Paypal changed their website and therefore also the JSON fetched via `finance-dl` changed to this notation.