### PR TITLE
fix: #202 - missing checks during matching for number

### DIFF
--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -456,6 +456,10 @@ class PostingDatabase(object):
                     if posting_date and posting_date != date:
                         continue
 
+                # Verify that number is in fuzzy range
+                if abs(sp.number - amount.number) > self.fuzzy_match_amount:
+                    continue
+
                 key = _entry_and_posting_ids_key(sp.entry, sp.mp)
                 matches[key] = (sp.entry, sp.mp)
         return matches


### PR DESCRIPTION
8ccfee5 Changed the matching algorithm, and did not put in a check on the match_amount as had previously been done in _get_weight_matches.

This fix adds the check to ensure that the number is within the fuzzy range.