### PR TITLE
matching.py: Fix incorrect fuzzy amount loop bounds

### DIFF
--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -444,7 +444,11 @@ class PostingDatabase(object):
         if cur_matches is not None:
             lower_bound = bisect.bisect_left(cur_matches, (lower, tuple(), None, None))
             upper_bound = bisect.bisect_right(cur_matches, (upper, (sys.maxsize,), None, None), lo=lower_bound)
-            for sp in cur_matches[lower_bound-1 if lower_bound > 0 else 0:upper_bound]:
+            for sp in cur_matches[lower_bound:upper_bound]:
+                assert abs(sp.number - amount.number) <= self.fuzzy_match_amount, (
+                    f'Bug in matching algorithm: {sp} is not within '
+                    + f'{self.fuzzy_match_amount} of {amount}')
+
                 posting = sp.mp.posting
                 # Verify that the account is compatible.
                 if not are_accounts_mergeable(account, posting.account):

--- a/beancount_import/matching_test.py
+++ b/beancount_import/matching_test.py
@@ -750,6 +750,18 @@ def test_match_fuzzy_amount_upper_bound():
 
 def test_nonmatch_fuzzy_amount():
   # We don't match with a skew of 0.02, beyond our configured fuzzy_match_amount.
+  #
+  # This test case searches for matches for the "Expenses:FIXME 100 USD"
+  # posting among the following 4 candidates, ordered by amount:
+  #
+  # 1. Income:A -100 USD
+  # 2. Expenses:FIXME -99.98 USD
+  # 3. Assets:B 99.98 STOCK { 1.00 USD }
+  # 4. Expenses:FIXME 100 USD
+  #
+  # Only posting #1 should be considered; the others are beyond the
+  # fuzzy_match_amount. But since posting #1 is from the same transaction as the
+  # original posting, it should be excluded and no match should be returned.
   assert_match(
       pending_candidate="""
       2016-01-01 * "Narration"
@@ -766,21 +778,34 @@ def test_nonmatch_fuzzy_amount():
         Expenses:FIXME -99.98 USD
       """)
 
-def test_nonmatch_fuzzy_amount_with_dates():
+def test_nonmatch_fuzzy_amount_2():
   # We don't match with a skew of 0.02, beyond our configured fuzzy_match_amount.
+  #
+  # This test case searches for matches for the "Expenses:FIXME -20.00 USD"
+  # posting among the following 4 candidates, ordered by amount:
+  #
+  # 1. Expenses:FIXME -20.00 USD
+  # 2. Assets:B -19.98 USD
+  # 3. Expenses:FIXME 19.98 USD
+  # 4. Assets:A 20.00 USD
+  #
+  # Only posting #4 should be considered; the others are beyond the
+  # fuzzy_match_amount. But since posting #4 is from the same transaction as the
+  # original posting, it should be excluded and no match should be returned.
+  #
+  # The difference between this test case and `test_nonmatch_fuzzy_amount()`
+  # above is the position of the target posting within the candidates list: at
+  # the end of the list rather than the beginning. This test case reproduces
+  # issue #202.
   assert_match(
       pending_candidate="""
       2023-01-01 * "Transaction 0"
         Assets:A 20.00 USD
-          date: 2023-01-01
-          cleared: TRUE
         Expenses:FIXME -20.00 USD
       """,
       pending="""
       2023-01-01 * "Transaction 1"
         Assets:B -19.98 USD
-          date: 2023-01-01
-          cleared: TRUE
         Expenses:FIXME 19.98 USD
       """)
 

--- a/beancount_import/matching_test.py
+++ b/beancount_import/matching_test.py
@@ -721,6 +721,33 @@ def test_match_fuzzy_amount():
           note: "B"
       """)
 
+def test_match_fuzzy_amount_upper_bound():
+  # We match despite a skew of 0.01 USD, our configured fuzzy_match_amount.
+  assert_match(
+      pending_candidate="""
+      2016-01-01 * "Narration"
+        note: "A"
+        Income:A -100 USD
+          note: "A"
+        Expenses:FIXME 100 USD
+      """,
+      pending="""
+      2016-01-01 * "Narration"
+        note2: "B"
+        Assets:B 100.01 STOCK { 1.00 USD }
+          note: "B"
+        Expenses:FIXME -100.01 USD
+      """,
+      matches="""
+      2016-01-01 * "Narration"
+        note: "A"
+        note2: "B"
+        Income:A -100 USD
+          note: "A"
+        Assets:B 100.01 STOCK { 1.00 USD }
+          note: "B"
+      """)
+
 def test_nonmatch_fuzzy_amount():
   # We don't match with a skew of 0.02, beyond our configured fuzzy_match_amount.
   assert_match(
@@ -737,6 +764,24 @@ def test_nonmatch_fuzzy_amount():
         Assets:B 99.98 STOCK { 1.00 USD }
           note: "B"
         Expenses:FIXME -99.98 USD
+      """)
+
+def test_nonmatch_fuzzy_amount_with_dates():
+  # We don't match with a skew of 0.02, beyond our configured fuzzy_match_amount.
+  assert_match(
+      pending_candidate="""
+      2023-01-01 * "Transaction 0"
+        Assets:A 20.00 USD
+          date: 2023-01-01
+          cleared: TRUE
+        Expenses:FIXME -20.00 USD
+      """,
+      pending="""
+      2023-01-01 * "Transaction 1"
+        Assets:B -19.98 USD
+          date: 2023-01-01
+          cleared: TRUE
+        Expenses:FIXME 19.98 USD
       """)
 
 def test_match_grouped_differing_signs():


### PR DESCRIPTION
The [indexing logic](https://github.com/jbms/beancount-import/commit/8ccfee5b4ce662f8e070a90a9c0961769488391e#diff-1d4595bc7bf509394ca45262f4656c4b180c83a7be5e6cb653b7265d29743c97R445) in `matching.py` has an off-by-one bug that manifests as #202.

We currently modify the lower bound of the loop to include an element less than the lower bound:
```python
for sp in cur_matches[lower_bound-1 if lower_bound > 0 else 0:upper_bound]:
    # Verify that number is in fuzzy range.
    # Currently fails (issue #202).
    assert abs(sp.number - amount.number) <= self.fuzzy_match_amount
```

Removing that fixes the problem:
```python
for sp in cur_matches[lower_bound:upper_bound]:
    # Verify that number is in fuzzy range.
    # No longer fails.
    assert abs(sp.number - amount.number) <= self.fuzzy_match_amount
```

This approach is an alternative to https://github.com/jbms/beancount-import/pull/206.

In addition to the loop bounds fix, this PR adds the following:
- The above loop assertion.
- `test_nonmatch_fuzzy_amount_with_dates`: a repro for #202. It previously failed and now passes.
- `test_match_fuzzy_amount_upper_bound`: exercises the loop's upper bound handling. Injecting an off-by-one error in the upper bound by changing `upper_bound` to `upper_bound-1` causes this test to fail.

Fixes #202.