### PR TITLE
Sort meta keys before printing to fix tests broken by Beancount 2.3.6

### DIFF
--- a/beancount_import/journal_editor.py
+++ b/beancount_import/journal_editor.py
@@ -37,6 +37,8 @@ import beancount.parser.printer
 import beancount.parser.booking
 from beancount.core.number import MISSING
 
+from .sorted_entry_printer import SortedEntryPrinter
+
 # Inclusive starting original line, exclusive ending original line.
 LineRange = Tuple[int, int]
 
@@ -820,7 +822,7 @@ class StagedChanges(object):
         new_entries = []
         old_entries = []
 
-        printer = beancount.parser.printer.EntryPrinter()
+        printer = SortedEntryPrinter()
 
         for filename, changed_entries in self.changed_entries.items():
             changed_entries.sort(key=lambda x: float('inf')

--- a/beancount_import/sorted_entry_printer.py
+++ b/beancount_import/sorted_entry_printer.py
@@ -1,0 +1,19 @@
+import beancount.parser.printer
+
+
+class SortedEntryPrinter(beancount.parser.printer.EntryPrinter):
+    """A subclass of EntryPrinter that sorts the meta keys before printing.
+
+    This preserves the behavior of EntryPrinter from Beancount 2.3.5 and
+    earlier.
+
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def write_metadata(self, meta, oss, prefix=None):
+        if meta is None:
+            sorted_meta = None
+        else:
+            sorted_meta = dict(sorted(meta.items()))
+        super().write_metadata(sorted_meta, oss, prefix)

--- a/beancount_import/test_util.py
+++ b/beancount_import/test_util.py
@@ -10,6 +10,8 @@ import beancount.parser.parser
 import beancount.parser.printer
 from beancount.core.data import Directive, Entries, Posting, Transaction, Meta
 
+from .sorted_entry_printer import SortedEntryPrinter
+
 
 def parse(text: str) -> Entries:
     entries, errors, options = beancount.parser.parser.parse_string(
@@ -19,8 +21,7 @@ def parse(text: str) -> Entries:
 
 
 def format_entries(entries: Entries, indent=0):
-    result = '\n\n'.join(
-        beancount.parser.printer.format_entry(e) for e in entries)
+    result = '\n\n'.join(SortedEntryPrinter()(e) for e in entries)
     indent_str = ' ' * indent
     return '\n'.join(indent_str + x.rstrip() for x in result.split('\n'))
 


### PR DESCRIPTION
https://github.com/beancount/beancount/pull/726 (released in Beancount 2.3.6) changed the sort order of posting meta items when converting postings to strings. The meta items were previously printed in sorted order, and now are printed in insertion order. This breaks most beancount-import tests because they determine correctness by comparing transactions' string representations.

This PR introduces `SortedEntryPrinter`, which wraps Beancount's `EntryPrinter` and restores the previous behavior. It uses `SortedEntryPrinter` in the two places where tests rely on sort order. This fixes the tests.

Fixes #212.