### PR TITLE
Add BANK_INTEREST_ADJ and BANK_TRANSFER actions for Schwab CSV import

### DIFF
--- a/beancount_import/source/schwab_csv.py
+++ b/beancount_import/source/schwab_csv.py
@@ -154,6 +154,8 @@ class BrokerageAction(enum.Enum):
     # Please keep these alphabetized:
     ADR_MGMT_FEE = "ADR Mgmt Fee"
     BANK_INTEREST = "Bank Interest"
+    BANK_INTEREST_ADJ = "Bank Interest Adj"
+    BANK_TRANSFER = "Bank Transfer"
     BOND_INTEREST = "Bond Interest"
     BUY = "Buy"
     BUY_TO_CLOSE = "Buy to Close"
@@ -370,7 +372,8 @@ class RawBrokerageEntry(RawEntry):
                            BrokerageAction.SECURITY_TRANSFER,
                            BrokerageAction.WIRE_FUNDS,
                            BrokerageAction.WIRE_FUNDS_RECEIVED,
-                           BrokerageAction.FUNDS_RECEIVED):
+                           BrokerageAction.FUNDS_RECEIVED,
+                           BrokerageAction.BANK_TRANSFER):
             return Transfer(**shared_attrs)
         if self.action in (BrokerageAction.SELL,
                             BrokerageAction.SELL_TO_OPEN,
@@ -420,7 +423,9 @@ class RawBrokerageEntry(RawEntry):
             return Fee(fees_account=fees_account, **shared_attrs)
         if self.action == BrokerageAction.FOREIGN_TAX_PAID:
             return TaxPaid(taxes_account=taxes_account, **shared_attrs)
-        if self.action == BrokerageAction.MARGIN_INTEREST or self.action == BrokerageAction.CREDIT_INTEREST:
+        if self.action in (BrokerageAction.MARGIN_INTEREST,
+                           BrokerageAction.CREDIT_INTEREST,
+                           BrokerageAction.BANK_INTEREST_ADJ):
             return Interest(interest_account=interest_account, **shared_attrs)
         if self.action == BrokerageAction.EXPIRED:
             assert self.quantity is not None

--- a/testdata/source/schwab_csv/test_basic/import_results.beancount
+++ b/testdata/source/schwab_csv/test_basic/import_results.beancount
@@ -941,3 +941,67 @@
     schwab_action: "Short Term Cap Gain Reinvest"
     source_desc: "ISHARES GLOBAL CLEAN ENERGY ETF"
   Income:Dividend:Schwab:ICLN        -2.11 USD
+
+;; date: 2023-10-26
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 23, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-101.01 USD",
+;               "date": "2023-10-26",
+;               "key_value_pairs": {
+;                 "desc": "OVERDRAFT TO INVESTOR CHECKING 5678",
+;                 "schwab_action": "Bank Transfer"
+;               },
+;               "source_account": "Assets:Schwab:Brokerage-1234:Cash"
+;             }
+;           ]
+2023-10-26 * "TRANSFER - OVERDRAFT TO INVESTOR CHECKING 5678"
+  Assets:Schwab:Brokerage-1234:Cash  -101.01 USD
+    date: 2023-10-26
+    schwab_action: "Bank Transfer"
+    source_desc: "OVERDRAFT TO INVESTOR CHECKING 5678"
+  Expenses:FIXME                      101.01 USD
+
+;; date: 2023-10-29
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 24, "type": "text/csv"}
+
+; features: [
+;             {
+;               "amount": "-202.02 USD",
+;               "date": "2023-10-29",
+;               "key_value_pairs": {
+;                 "desc": "OVERDRAFT TO INVESTOR CHECKING 5678",
+;                 "schwab_action": "Bank Transfer"
+;               },
+;               "source_account": "Assets:Schwab:Brokerage-1234:Cash"
+;             }
+;           ]
+2023-10-29 * "TRANSFER - OVERDRAFT TO INVESTOR CHECKING 5678"
+  Assets:Schwab:Brokerage-1234:Cash  -202.02 USD
+    date: 2023-10-29
+    schwab_action: "Bank Transfer"
+    source_desc: "OVERDRAFT TO INVESTOR CHECKING 5678"
+  Expenses:FIXME                      202.02 USD
+
+;; date: 2023-10-30
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 25, "type": "text/csv"}
+
+; features: []
+2023-10-30 * "Margin Interest - INTEREST 09/28THRU 10/29"
+  Assets:Schwab:Brokerage-1234:Cash  -0.15 USD
+    date: 2023-10-30
+    schwab_action: "Margin Interest"
+    source_desc: "INTEREST 09/28THRU 10/29"
+  Income:Interest:Schwab              0.15 USD
+
+;; date: 2023-10-31
+;; info: {"filename": "<testdata>/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV", "line": 26, "type": "text/csv"}
+
+; features: []
+2023-10-31 * "Bank Interest Adj - BANK INA 103023-103023 SCHWAB BANK"
+  Assets:Schwab:Brokerage-1234:Cash  -0.01 USD
+    date: 2023-10-31
+    schwab_action: "Bank Interest Adj"
+    source_desc: "BANK INA 103023-103023 SCHWAB BANK"
+  Income:Interest:Schwab              0.01 USD

--- a/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV
+++ b/testdata/source/schwab_csv/test_basic/transactions/Brokerage_Transactions_20201115-180021.CSV
@@ -21,4 +21,8 @@
 "04/20/2022","Pr Yr Div Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
 "04/21/2022","Long Term Cap Gain Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
 "04/22/2022","Short Term Cap Gain Reinvest","ICLN","ISHARES GLOBAL CLEAN ENERGY ETF","","","","$2.11",
+"10/26/2023","Bank Transfer","","OVERDRAFT TO INVESTOR CHECKING 5678","","","","-$101.01",
+"10/30/2023 as of 10/29/2023","Bank Transfer","","OVERDRAFT TO INVESTOR CHECKING 5678","","","","-$202.02",
+"10/30/2023","Margin Interest","","INTEREST 09/28THRU 10/29","","","","-$0.15",
+"10/31/2023","Bank Interest Adj","","BANK INA 103023-103023 SCHWAB BANK","","","","-$0.01",
 Transactions Total,"","","","","","",$0.00


### PR DESCRIPTION
These actions appeared in my recent Schwab transactions CSV.

"Bank Interest Adj" seems to mean that the previous "Margin Interest" amount needed to be adjusted (in my case the adjustment amount was a penny).

"Bank Transfer" happens when you overdraw your checking account and the balance is automatically transferred from your brokerage account. (There doesn't seem to be a penalty for this so it seems like a nice way to simplify your accounts; just keep $0 in your checking account always and then when you pay bills it will automatically come out of your brokerage account).

Note: "Margin Interest" and "Bank Interest Adj" are treated as negative income, but I think it's more correct to treat them as an expense. This PR just preserves the existing behavior; I'll open a different PR to change it since it's orthogonal.