### PR TITLE
Limit the search for posting matches in extreme cases

### DIFF
--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -869,7 +869,6 @@ def _get_uncleared_aggregate_posting_candidates(
                                  []).append(posting)
 
     results = [] # type: List[Posting]
-    max_subset_size = 4
     sum_to_zero = set()  # type: Set[Tuple[int, ...]]
 
     def posting_set_id(postings):
@@ -905,6 +904,7 @@ def _get_uncleared_aggregate_posting_candidates(
         l.append((aggregate_posting, tuple(subset)))
 
     for (account, currency), posting_list in possible_sets.items():
+        max_subset_size = 4 if len(posting_list) < 25 else 1
         if len(posting_list) == 1:
             continue
         if len(posting_list) > max_subset_size:

--- a/beancount_import/matching.py
+++ b/beancount_import/matching.py
@@ -1783,8 +1783,9 @@ def get_extended_transactions(
                 excluded_transaction_ids=cast(FrozenSet[int],
                                               used_transaction_ids),
                 debug_level=level):
-            maybe_extend_candidate(new_transaction, matching_transaction,
-                                   level + 1)
+            if level <= 6:
+                maybe_extend_candidate(new_transaction, matching_transaction,
+                                       level + 1)
 
     maybe_extend_candidate(initial_transaction, initial_transaction, level=0)
 


### PR DESCRIPTION
Sometimes, particularly when there are a couple transactions with many smallish postings (like big Amazon orders), the combinatorial explosion of possible matching sets of transactions becomes intractable to search. These two small changes set limits on both the depth and breadth of searches for matching posting sets, because failing to find the right combination of transactions is preferable to pegging the CPU until beancount-import is forcibly killed.