### PR TITLE
Some minor improvements to the healthequity source

### DIFF
--- a/testdata/source/healthequity/test_basic/import_results.beancount
+++ b/testdata/source/healthequity/test_basic/import_results.beancount
@@ -221,11 +221,6 @@
   Assets:HSA:HealthEquity:Cash   -1936.76 USD
 
 ;; date: 2016-03-12
-;; info: {"filename": "<testdata>/data/1234567/cash-transactions-other.csv", "line": 5, "type": "text/csv"}
-
-2016-03-12 balance Assets:HSA:HealthEquity:Cash                    500.00 USD
-
-;; date: 2016-03-12
 ;; info: {"filename": "<testdata>/data/1234567/investment-transactions.csv", "line": 3, "type": "text/csv"}
 
 2016-03-12 balance Assets:HSA:HealthEquity:VIIIX                   10.436 VIIIX

--- a/testdata/source/healthequity/test_invalid/import_results.beancount
+++ b/testdata/source/healthequity/test_invalid/import_results.beancount
@@ -34,11 +34,6 @@
 2016-03-01 balance Assets:HSA:HealthEquity:Cash                    836.76 USD
 
 ;; date: 2016-03-12
-;; info: {"filename": "<testdata>/data/1234567/cash-transactions-other.csv", "line": 5, "type": "text/csv"}
-
-2016-03-12 balance Assets:HSA:HealthEquity:Cash                    500.00 USD
-
-;; date: 2016-03-12
 ;; info: {"filename": "<testdata>/data/1234567/investment-transactions.csv", "line": 3, "type": "text/csv"}
 
 2016-03-12 balance Assets:HSA:HealthEquity:VIIIX                   10.436 VIIIX

--- a/testdata/source/healthequity/test_matching/import_results.beancount
+++ b/testdata/source/healthequity/test_matching/import_results.beancount
@@ -34,11 +34,6 @@
 2016-03-01 balance Assets:HSA:HealthEquity:Cash                    836.76 USD
 
 ;; date: 2016-03-12
-;; info: {"filename": "<testdata>/data/1234567/cash-transactions-other.csv", "line": 5, "type": "text/csv"}
-
-2016-03-12 balance Assets:HSA:HealthEquity:Cash                    500.00 USD
-
-;; date: 2016-03-12
 ;; info: {"filename": "<testdata>/data/1234567/investment-transactions.csv", "line": 3, "type": "text/csv"}
 
 2016-03-12 balance Assets:HSA:HealthEquity:VIIIX                   10.436 VIIIX


### PR DESCRIPTION
Bugfix:
* Don't output balance assertions when there are multiple transactions on the same day, because we don't know which one incorporates all the transactions.

New feature:
* Support `ignore_before` option in healthequity sources to ignore all transactions before a given date (say, before the journal was established).