### PR TITLE
Minor improvements to the ultipro source

### DIFF
--- a/beancount_import/source/ultipro_google.py
+++ b/beancount_import/source/ultipro_google.py
@@ -321,8 +321,7 @@ class UltiproSource(Config, Source):
             documents_seen_in_directory.add(seen_key)
             if seen_key in documents_seen_in_journal:
                 continue
-            parsed_statements.append((pay_date, document_number, parse_result,
-                                      filename))
+            parsed_statements.append((pay_date, document_number, parse_result, path))
 
         rules = self.rules.copy()
         rules.setdefault('Net Pay Distribution', []).extend(net_pay_rules)
@@ -349,7 +348,7 @@ class UltiproSource(Config, Source):
             return FIXME_ACCOUNT
 
         parsed_statements.sort(key=lambda x: (x[0], x[1]))
-        for pay_date, _, parse_result, filename in parsed_statements:
+        for pay_date, _, parse_result, path in parsed_statements:
             results.add_pending_entry(
                 self._get_import_result(
                     parse_result,

--- a/beancount_import/source/ultipro_google_statement.py
+++ b/beancount_import/source/ultipro_google_statement.py
@@ -35,10 +35,10 @@ def parse(text: str) -> ParseResult:
     number_re = r'[0-9]+'
     account_re = r'[0-9x]+'
 
-    # One or more space separated words.  Each word starts with
-    # alphanumeric and remaining characters are alphanumeric + hyphen. A
-    # single hyphen is also allowed as a word after the first word.
-    field_name_re = r'[0-9a-zA-Z][0-9a-zA-Z\-]*(?:[ \n]+(?:[0-9a-zA-Z][0-9a-zA-Z\-]*|-)(?:\.)?)*'
+    # One or more space separated words. Each word starts with alphanumeric
+    # and remaining characters are alphanumeric + hyphen + slash. A single
+    # hyphen is also allowed as a word after the first word.
+    field_name_re = r'[0-9a-zA-Z][0-9a-zA-Z\-/]*(?:[ \n]+(?:[0-9a-zA-Z][0-9a-zA-Z\-/]*|-)(?:\.)?)*'
 
     def parse_date(x: str) -> datetime.date:
         return datetime.datetime.strptime(x, '%m/%d/%Y').date()


### PR DESCRIPTION
* use the correct filename for generated `ImportResult`s rather than always using the lexicographically-last pathname in the source directory (a bug that is invisible unless one misses a beancount-import run and so there are at least two statements to import)
* allow slashes in row names, because I have a single pay statement that uses `Earnings: Prize/ Gift` as a line item