### PR TITLE
Proof of concept payee prediction

### DIFF
--- a/beancount_import/training.py
+++ b/beancount_import/training.py
@@ -52,8 +52,10 @@ def get_features(example: PredictionInput) -> Dict[str, bool]:
 class TrainingExamples(object):
     def __init__(self):
         self.training_examples = []
+        self.payee_examples = []
 
-    def add(self, example: PredictionInput, target_account: str):
+    def add(self, example: PredictionInput, target_account: str, target_payee: str):
+        self.payee_examples.append((get_features(example), target_payee))
         self.training_examples.append((get_features(example), target_account))
 
 
@@ -182,6 +184,7 @@ class FeatureExtractor(object):
                             date=entry.date,
                             key_value_pairs=key_value_pairs),
                         target_account=posting.account,
+                        target_payee=entry.payee,
                     )
             if got_example: continue
 
@@ -208,7 +211,8 @@ class FeatureExtractor(object):
                         key_value_pairs=key_value_pairs,
                         date=get_posting_date(entry, posting),
                         amount=posting.units),
-                    target_account=target_account)
+                    target_account=target_account,
+                    target_payee=entry.payee)
 
     def extract_unknown_account_group_features(
             self, transaction: Transaction) -> List[Optional[PredictionInput]]:


### PR DESCRIPTION
My credit card imports produce narrations that aren't super useful/recognizable as actual companies. Especially with square and other payment providers reducing the amount of characters businesses seem to have available, and merchants like Amazon with tons of random seeming permutations of names. Ideally I'd like to apply nice readable names to my transactions for review and later reporting, I think that would be nicer than a sub-account in expenses for ever single merchant.

Does this seem like a useful path to follow? I'm light on python skills but this branch is just barely enough code to work as a proof of concept and no ui affordances.